### PR TITLE
Apply dashboard-style panel visual redesign

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,6 @@ group :jekyll_plugins do
     gem 'jekyll-toc'
     gem 'jekyll-twitter-plugin'
     gem 'jemoji'
-    gem 'mini_racer'
     gem 'unicode_utils'
     gem 'webrick'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,102 +1,135 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.2.1)
+    activesupport (8.1.3)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.3.1)
       connection_pool (>= 2.2.5)
       drb
       i18n (>= 1.6, < 2)
+      json
       logger (>= 1.4.2)
       minitest (>= 5.1)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
-    addressable (2.8.7)
-      public_suffix (>= 2.0.2, < 7.0)
-    base64 (0.2.0)
-    bibtex-ruby (6.1.0)
+      uri (>= 0.13.1)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
+    base64 (0.3.0)
+    bibtex-ruby (6.2.0)
       latex-decode (~> 0.0)
+      logger (~> 1.7)
       racc (~> 1.7)
-    bigdecimal (3.1.8)
-    citeproc (1.0.10)
+    bigdecimal (4.1.2)
+    citeproc (1.1.0)
+      date
+      forwardable
+      json
       namae (~> 1.0)
-    citeproc-ruby (1.1.14)
+      observer (< 1.0)
+      open-uri (< 1.0)
+    citeproc-ruby (2.1.8)
       citeproc (~> 1.0, >= 1.0.9)
-      csl (~> 1.6)
+      csl (~> 2.0)
+      observer (< 1.0)
     classifier-reborn (2.3.0)
       fast-stemmer (~> 1.0)
       matrix (~> 0.4)
     colorator (1.1.0)
-    concurrent-ruby (1.3.4)
-    connection_pool (2.4.1)
+    concurrent-ruby (1.3.6)
+    connection_pool (3.0.2)
     crass (1.0.6)
-    csl (1.6.0)
-      namae (~> 1.0)
-      rexml
-    csl-styles (1.0.1.11)
-      csl (~> 1.0)
-    css_parser (1.19.0)
+    csl (2.2.1)
+      forwardable (~> 1.3)
+      namae (~> 1.2)
+      open-uri (< 1.0)
+      rexml (~> 3.0)
+      set (~> 1.1)
+      singleton (< 1.0)
+      time (< 1.0)
+    csl-styles (2.0.2)
+      csl (~> 2.0)
+    css_parser (1.21.1)
       addressable
-    cssminify2 (2.0.1)
-    csv (3.3.0)
+    cssminify2 (2.1.0)
+    csv (3.3.5)
+    date (3.5.1)
     deep_merge (1.2.2)
-    drb (2.2.1)
+    drb (2.2.3)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
-    execjs (2.9.1)
+    execjs (2.10.1)
     fast-stemmer (1.0.2)
-    feedjira (3.2.3)
+    feedjira (4.0.2)
+      logger (>= 1.0, < 2)
       loofah (>= 2.3.1, < 3)
       sax-machine (>= 1.0, < 2)
-    ffi (1.17.0-aarch64-linux-gnu)
-    ffi (1.17.0-arm64-darwin)
-    ffi (1.17.0-x86_64-darwin)
-    ffi (1.17.0-x86_64-linux-gnu)
+    ffi (1.17.4-aarch64-linux-gnu)
+    ffi (1.17.4-aarch64-linux-musl)
+    ffi (1.17.4-arm-linux-gnu)
+    ffi (1.17.4-arm-linux-musl)
+    ffi (1.17.4-arm64-darwin)
+    ffi (1.17.4-x86_64-darwin)
+    ffi (1.17.4-x86_64-linux-gnu)
+    ffi (1.17.4-x86_64-linux-musl)
+    forwardable (1.4.0)
     forwardable-extended (2.6.0)
     gemoji (4.1.0)
-    google-protobuf (4.28.2-aarch64-linux)
+    google-protobuf (4.34.1)
       bigdecimal
-      rake (>= 13)
-    google-protobuf (4.28.2-arm64-darwin)
+      rake (~> 13.3)
+    google-protobuf (4.34.1-aarch64-linux-gnu)
       bigdecimal
-      rake (>= 13)
-    google-protobuf (4.28.2-x86_64-darwin)
+      rake (~> 13.3)
+    google-protobuf (4.34.1-aarch64-linux-musl)
       bigdecimal
-      rake (>= 13)
-    google-protobuf (4.28.2-x86_64-linux)
+      rake (~> 13.3)
+    google-protobuf (4.34.1-arm64-darwin)
       bigdecimal
-      rake (>= 13)
+      rake (~> 13.3)
+    google-protobuf (4.34.1-x86_64-darwin)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.34.1-x86_64-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.34.1-x86_64-linux-musl)
+      bigdecimal
+      rake (~> 13.3)
     html-pipeline (2.14.3)
       activesupport (>= 2)
       nokogiri (>= 1.4)
     htmlcompressor (0.4.0)
-    http_parser.rb (0.8.0)
-    httparty (0.22.0)
+    http_parser.rb (0.8.1)
+    httparty (0.24.2)
       csv
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
-    i18n (1.14.6)
+    i18n (1.14.8)
       concurrent-ruby (~> 1.0)
-    jekyll (4.3.4)
+    jekyll (4.4.1)
       addressable (~> 2.4)
+      base64 (~> 0.2)
       colorator (~> 1.0)
+      csv (~> 3.0)
       em-websocket (~> 0.5)
       i18n (~> 1.0)
       jekyll-sass-converter (>= 2.0, < 4.0)
       jekyll-watch (~> 2.0)
+      json (~> 2.6)
       kramdown (~> 2.3, >= 2.3.1)
       kramdown-parser-gfm (~> 1.0)
       liquid (~> 4.0)
-      mercenary (>= 0.3.6, < 0.5)
+      mercenary (~> 0.3, >= 0.3.6)
       pathutil (~> 0.9)
       rouge (>= 3.0, < 5.0)
       safe_yaml (~> 1.0)
       terminal-table (>= 1.8, < 4.0)
       webrick (~> 1.7)
-    jekyll-archives (2.2.1)
+    jekyll-archives (2.3.0)
       jekyll (>= 3.6, < 5.0)
     jekyll-email-protect (1.1.0)
     jekyll-feed (0.17.0)
@@ -108,22 +141,22 @@ GEM
       jekyll (>= 3.4)
     jekyll-jupyter-notebook (0.0.6)
       jekyll
-    jekyll-link-attributes (1.0.1)
-    jekyll-minifier (0.1.10)
-      cssminify2 (~> 2.0)
+    jekyll-link-attributes (2.0.1)
+    jekyll-minifier (0.2.2)
+      cssminify2 (~> 2.1.0)
       htmlcompressor (~> 0.4)
-      jekyll (>= 3.5)
+      jekyll (~> 4.0)
       json-minify (~> 0.0.3)
-      uglifier (~> 4.1)
+      terser (~> 1.2.3)
     jekyll-paginate-v2 (3.0.0)
       jekyll (>= 3.0, < 5.0)
     jekyll-regex-replace (1.1.0)
-    jekyll-sass-converter (3.0.0)
-      sass-embedded (~> 1.54)
-    jekyll-scholar (7.1.3)
+    jekyll-sass-converter (3.1.0)
+      sass-embedded (~> 1.75)
+    jekyll-scholar (7.3.0)
       bibtex-ruby (~> 6.0)
-      citeproc-ruby (~> 1.0)
-      csl-styles (~> 1.0)
+      citeproc-ruby (>= 2.1.6)
+      csl-styles (~> 2.0)
       jekyll (~> 4.0)
     jekyll-sitemap (1.4.0)
       jekyll (>= 3.7, < 5.0)
@@ -139,80 +172,111 @@ GEM
       gemoji (>= 3, < 5)
       html-pipeline (~> 2.2)
       jekyll (>= 3.0, < 5.0)
-    json (2.7.2)
+    json (2.19.4)
     json-minify (0.0.3)
       json (> 0)
-    kramdown (2.4.0)
-      rexml
+    kramdown (2.5.2)
+      rexml (>= 3.4.4)
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
-    latex-decode (0.4.0)
-    libv8-node (22.7.0.4-aarch64-linux)
-    libv8-node (22.7.0.4-arm64-darwin)
-    libv8-node (22.7.0.4-x86_64-darwin)
-    libv8-node (22.7.0.4-x86_64-linux)
+    latex-decode (0.4.2)
     liquid (4.0.4)
-    listen (3.9.0)
+    listen (3.10.0)
+      logger
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    logger (1.6.1)
-    loofah (2.22.0)
+    logger (1.7.0)
+    loofah (2.25.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    matrix (0.4.2)
+    matrix (0.4.3)
     mercenary (0.4.0)
     mini_mime (1.1.5)
-    mini_racer (0.15.0)
-      libv8-node (~> 22.7.0.1)
-    minitest (5.25.1)
-    multi_xml (0.7.1)
-      bigdecimal (~> 3.1)
+    minitest (6.0.6)
+      drb (~> 2.0)
+      prism (~> 1.5)
+    multi_xml (0.8.1)
+      bigdecimal (>= 3.1, < 5)
     namae (1.2.0)
       racc (~> 1.7)
-    nokogiri (1.16.7-aarch64-linux)
+    nokogiri (1.19.3-aarch64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.16.7-arm64-darwin)
+    nokogiri (1.19.3-aarch64-linux-musl)
       racc (~> 1.4)
-    nokogiri (1.16.7-x86_64-darwin)
+    nokogiri (1.19.3-arm-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.16.7-x86_64-linux)
+    nokogiri (1.19.3-arm-linux-musl)
       racc (~> 1.4)
+    nokogiri (1.19.3-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.3-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.3-x86_64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.3-x86_64-linux-musl)
+      racc (~> 1.4)
+    observer (0.1.2)
+    open-uri (0.5.0)
+      stringio
+      time
+      uri
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (6.0.1)
+    prism (1.9.0)
+    public_suffix (7.0.5)
     racc (1.8.1)
-    rake (13.2.1)
+    rake (13.4.2)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rexml (3.3.7)
-    rouge (4.4.0)
+    rexml (3.4.4)
+    rouge (4.7.0)
     safe_yaml (1.0.5)
-    sass-embedded (1.79.3-aarch64-linux-gnu)
-      google-protobuf (~> 4.27)
-    sass-embedded (1.79.3-arm64-darwin)
-      google-protobuf (~> 4.27)
-    sass-embedded (1.79.3-x86_64-darwin)
-      google-protobuf (~> 4.27)
-    sass-embedded (1.79.3-x86_64-linux-gnu)
-      google-protobuf (~> 4.27)
+    sass-embedded (1.99.0-aarch64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.99.0-aarch64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.99.0-arm-linux-gnueabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.99.0-arm-linux-musleabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.99.0-arm64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.99.0-x86_64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.99.0-x86_64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.99.0-x86_64-linux-musl)
+      google-protobuf (~> 4.31)
     sax-machine (1.3.2)
-    securerandom (0.3.1)
+    securerandom (0.4.1)
+    set (1.1.3)
+    singleton (0.3.0)
+    stringio (3.2.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
+    terser (1.2.7)
+      execjs (>= 0.3.0, < 3)
+    time (0.4.2)
+      date
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    uglifier (4.2.1)
-      execjs (>= 0.3.0, < 3)
     unicode-display_width (2.6.0)
     unicode_utils (1.4.0)
-    webrick (1.8.2)
+    uri (1.1.1)
+    webrick (1.9.2)
 
 PLATFORMS
-  aarch64-linux
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-gnueabihf
+  arm-linux-musl
+  arm-linux-musleabihf
   arm64-darwin
   x86_64-darwin
-  x86_64-linux
+  x86_64-linux-gnu
+  x86_64-linux-musl
 
 DEPENDENCIES
   classifier-reborn
@@ -236,9 +300,133 @@ DEPENDENCIES
   jekyll-toc
   jekyll-twitter-plugin
   jemoji
-  mini_racer
   unicode_utils
   webrick
 
+CHECKSUMS
+  activesupport (8.1.3) sha256=21a5e0dfbd4c3ddd9e1317ec6a4d782fa226e7867dc70b0743acda81a1dca20e
+  addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
+  base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
+  bibtex-ruby (6.2.0) sha256=d610eba78d6adf503a843daf144644449fb34e7c3f4a75e9ab67fae5dfd7c69a
+  bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
+  citeproc (1.1.0) sha256=278e6b8948133e82bef1c8204a1f88ca7adaa8744b9a283fe73e8f4cd0b53b95
+  citeproc-ruby (2.1.8) sha256=192ce6525235adaa60d1dbc3f1b10b0839e86d98a94278736b807e234b3572e9
+  classifier-reborn (2.3.0) sha256=e2236322de42b9c8d45d88a951cb0d76e210afa3bb8658b7b5802e2df41ef61c
+  colorator (1.1.0) sha256=e2f85daf57af47d740db2a32191d1bdfb0f6503a0dfbc8327d0c9154d5ddfc38
+  concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
+  connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
+  crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
+  csl (2.2.1) sha256=624352f1f6f51f1e0b155bd2501ce423f03264495ec259e65c26e00872a195a2
+  csl-styles (2.0.2) sha256=a48007d8a60307825de140dc2adaacc0b7186f2d1042f7e839eb47fce051de98
+  css_parser (1.21.1) sha256=6cfd3ffc0a97333b39d2b1b49c95397b05e0e3b684d68f77ec471ba4ec2ef7c7
+  cssminify2 (2.1.0) sha256=406a0b95fdaab60132c6f1fbb47b4a30f9572d2ef523f806fb94a530d78c2bb1
+  csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
+  date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
+  deep_merge (1.2.2) sha256=83ced3a3d7f95f67de958d2ce41b1874e83c8d94fe2ddbff50c8b4b82323563a
+  drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
+  em-websocket (0.5.3) sha256=f56a92bde4e6cb879256d58ee31f124181f68f8887bd14d53d5d9a292758c6a8
+  eventmachine (1.2.7) sha256=994016e42aa041477ba9cff45cbe50de2047f25dd418eba003e84f0d16560972
+  execjs (2.10.1) sha256=abe0ae028467eb8e30c10814eb934d07876a691aae7e803d813b7ce5a75e73f1
+  fast-stemmer (1.0.2) sha256=d0aa9fd9cfbca836a09d8abb122552ac8234130271a3b0da1cb077323d650819
+  feedjira (4.0.2) sha256=3e7a90d24fd66eddc809539e637a86a02de1a7e038cd40157e916ed2f3b5ff71
+  ffi (1.17.4-aarch64-linux-gnu) sha256=b208f06f91ffd8f5e1193da3cae3d2ccfc27fc36fba577baf698d26d91c080df
+  ffi (1.17.4-aarch64-linux-musl) sha256=9286b7a615f2676245283aef0a0a3b475ae3aae2bb5448baace630bb77b91f39
+  ffi (1.17.4-arm-linux-gnu) sha256=d6dbddf7cb77bf955411af5f187a65b8cd378cb003c15c05697f5feee1cb1564
+  ffi (1.17.4-arm-linux-musl) sha256=9d4838ded0465bef6e2426935f6bcc93134b6616785a84ffd2a3d82bc3cf6f95
+  ffi (1.17.4-arm64-darwin) sha256=19071aaf1419251b0a46852abf960e77330a3b334d13a4ab51d58b31a937001b
+  ffi (1.17.4-x86_64-darwin) sha256=aa70390523cf3235096cf64962b709b4cfbd5c082a2cb2ae714eb0fe2ccda496
+  ffi (1.17.4-x86_64-linux-gnu) sha256=9d3db14c2eae074b382fa9c083fe95aec6e0a1451da249eab096c34002bc752d
+  ffi (1.17.4-x86_64-linux-musl) sha256=3fdf9888483de005f8ef8d1cf2d3b20d86626af206cbf780f6a6a12439a9c49e
+  forwardable (1.4.0) sha256=f1cd40cc9812937980e1c76f1aa053660990a7c9b6a98fc37d945468afcce838
+  forwardable-extended (2.6.0) sha256=1bec948c469bbddfadeb3bd90eb8c85f6e627a412a3e852acfd7eaedbac3ec97
+  gemoji (4.1.0) sha256=734434020cbe964ea9d19086798797a47d23a170892de0ce55b74aa65d2ddc1a
+  google-protobuf (4.34.1) sha256=347181542b8d659c60f028fa3791c9cccce651a91ad27782dbc5c5e374796cdc
+  google-protobuf (4.34.1-aarch64-linux-gnu) sha256=f9c07607dc139c895f2792a7740fcd01cd94d4d7b0e0a939045b50d7999f0b1d
+  google-protobuf (4.34.1-aarch64-linux-musl) sha256=db58e5a4a492b43c6614486aea31b7fb86955b175d1d48f28ebf388f058d78a9
+  google-protobuf (4.34.1-arm64-darwin) sha256=2745061f973119e6e7f3c81a0c77025d291a3caa6585a2cd24a25bbc7bedb267
+  google-protobuf (4.34.1-x86_64-darwin) sha256=4dc498376e218871613589c4d872400d42ad9ae0c700bdb2606fe1c77a593075
+  google-protobuf (4.34.1-x86_64-linux-gnu) sha256=87088c9fd8e47b5b40ca498fc1195add6149e941ff7e81c532a5b0b8876d4cc9
+  google-protobuf (4.34.1-x86_64-linux-musl) sha256=8c0e91436fbe504ffc64f0bd621f2e69adbcce8ed2c58439d7a21117069cfdd7
+  html-pipeline (2.14.3) sha256=8a1d4d7128b2141913387cac0f8ba898bb6812557001acc0c2b46910f59413a0
+  htmlcompressor (0.4.0) sha256=4630cf8ed46b563f0b49cc6028a3fe8c17a9067f2becd7c3a2aa5aaacefb1f9e
+  http_parser.rb (0.8.1) sha256=9ae8df145b39aa5398b2f90090d651c67bd8e2ebfe4507c966579f641e11097a
+  httparty (0.24.2) sha256=8fca6a54aa0c4aa4303a0fd33e5e2156175d6a5334f714263b458abd7fda9c38
+  i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
+  jekyll (4.4.1) sha256=4c1144d857a5b2b80d45b8cf5138289579a9f8136aadfa6dd684b31fe2bc18c1
+  jekyll-archives (2.3.0) sha256=2dbd8ce22212fbace81fe2c9aa4152a6e21c748bcc626f135af5acfd813375f6
+  jekyll-email-protect (1.1.0) sha256=00d620939c710788ae3f71188ef913e0aa7ff0a5a39f48249213ea6215558c8d
+  jekyll-feed (0.17.0) sha256=689aab16c877949bb9e7a5c436de6278318a51ecb974792232fd94d8b3acfcc3
+  jekyll-get-json (1.0.0) sha256=f6b076a93de9cace89a88617b494bea10e6dbb86331c293d663d37d9b9ae7522
+  jekyll-imagemagick (1.4.0) sha256=dcf4ae46ffbeabfac584a5256821e39fc5fae8d651fd5c4a56fef3a2061a7ef4
+  jekyll-jupyter-notebook (0.0.6) sha256=33f757eaad9035bebc5309e23ce2274db089ae8a0d002a53c3acbc5265d322cd
+  jekyll-link-attributes (2.0.1) sha256=e25b12e3c2a2960c8cfd9ab33e8df9aa3c4ba86491dbeec48f3cb11b0a0f216d
+  jekyll-minifier (0.2.2) sha256=f0a182b98b369492b9d93f1dd064223cf04a10ba31c49e1535f28fe35764ee19
+  jekyll-paginate-v2 (3.0.0) sha256=001be6c1963caa41fed9c2f43b0d47201defa0395381eb8830487c1c2fc4f4e3
+  jekyll-regex-replace (1.1.0) sha256=3738e6a0aa07dd3f9b7369e6e38e5d245c623bbd70c31b21e7838c654377a00c
+  jekyll-sass-converter (3.1.0) sha256=83925d84f1d134410c11d0c6643b0093e82e3a3cf127e90757a85294a3862443
+  jekyll-scholar (7.3.0) sha256=d912e60aa5ab342fb4322772f02674152e2799375612a2aa5f9b2228728fd09b
+  jekyll-sitemap (1.4.0) sha256=0de08c5debc185ea5a8f980e1025c7cd3f8e0c35c8b6ef592f15c46235cf4218
+  jekyll-tabs (1.2.1) sha256=e7e0f05d1180c9651318fb5834a0c745a613b4253e9699a662b63cc3d39cbc4d
+  jekyll-toc (0.19.0) sha256=8a8270f7e8e3d849e2035710b1713d0af5e2185a4bfaca70f9192ecf5ac50668
+  jekyll-twitter-plugin (2.1.0) sha256=d25ee86813705244dcec3163d9a110a1c0216e157dcf6cf88ab57cf389887acd
+  jekyll-watch (2.2.1) sha256=bc44ed43f5e0a552836245a54dbff3ea7421ecc2856707e8a1ee203a8387a7e1
+  jemoji (0.13.0) sha256=5d4c3e8e2cbbb2b73997c31294f6f70c94e4d4fade039373e86835bcf5529e7c
+  json (2.19.4) sha256=670a7d333fb3b18ca5b29cb255eb7bef099e40d88c02c80bd42a3f30fe5239ac
+  json-minify (0.0.3) sha256=fd38ef93867332c2340aaf1b57335782ab5958fe6fb3ca7a8aba1469f0bf08ae
+  kramdown (2.5.2) sha256=1ba542204c66b6f9111ff00dcc26075b95b220b07f2905d8261740c82f7f02fa
+  kramdown-parser-gfm (1.1.0) sha256=fb39745516427d2988543bf01fc4cf0ab1149476382393e0e9c48592f6581729
+  latex-decode (0.4.2) sha256=e85633406e315e348e0ca6de231dee1bf45a22496b0866059c635f7502c2a592
+  liquid (4.0.4) sha256=4fcfebb1a045e47918388dbb7a0925e7c3893e58d2bd6c3b3c73ec17a2d8fdb3
+  listen (3.10.0) sha256=c6e182db62143aeccc2e1960033bebe7445309c7272061979bb098d03760c9d2
+  logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
+  loofah (2.25.1) sha256=d436c73dbd0c1147b16c4a41db097942d217303e1f7728704b37e4df9f6d2e04
+  matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
+  mercenary (0.4.0) sha256=b25a1e4a59adca88665e08e24acf0af30da5b5d859f7d8f38fba52c28f405138
+  mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
+  minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
+  multi_xml (0.8.1) sha256=addba0290bac34e9088bfe73dc4878530297a82a7bbd66cb44dcd0a4b86edf5a
+  namae (1.2.0) sha256=3541ce4b086fd4981d2376630c03e284402bfe1cdbab4e50e2222a72aeb9d59d
+  nokogiri (1.19.3-aarch64-linux-gnu) sha256=46b89e5d7b9e844c2ee360794240c6ea2a4e6fa0c5892a4ed487db621224b639
+  nokogiri (1.19.3-aarch64-linux-musl) sha256=8392dfdcd21be7a94dbbe9ccc138dea01b97b24cb2dc02a114ca98bfb1d9a0b7
+  nokogiri (1.19.3-arm-linux-gnu) sha256=3919d5ffc334ad778a4a9eb88fda7dcb8b1fb58c8a52ac640c6dcd2f038e774f
+  nokogiri (1.19.3-arm-linux-musl) sha256=9ce1cb6346bb9c67b1550eb537aa183ead91e4b6eadb2f36ade02d8dd2a79fb6
+  nokogiri (1.19.3-arm64-darwin) sha256=71b9bd424b1b7abc18b05052a1a3cfd3627abdca62be280854cc411791357e42
+  nokogiri (1.19.3-x86_64-darwin) sha256=77f3fba57d46c53ab31e62fc6c28f705109d1bf6264356c76f132b2be5728d4d
+  nokogiri (1.19.3-x86_64-linux-gnu) sha256=2f5078620fe12e83669b5b17311b32532a8153d02eee7ad06948b926d6080976
+  nokogiri (1.19.3-x86_64-linux-musl) sha256=248c906d2166eca5efb56d52fdee5f9a1f51d69a72e2b64fdac647b4ce39ea3f
+  observer (0.1.2) sha256=d8a3107131ba661138d748e7be3dbafc0d82e732fffba9fccb3d7829880950ac
+  open-uri (0.5.0) sha256=7b4f06fdac39e6946aed15a8da82531580882fbbec80438adcb7c30d388887ca
+  pathutil (0.16.2) sha256=e43b74365631cab4f6d5e4228f812927efc9cb2c71e62976edcb252ee948d589
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
+  public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
+  rb-fsevent (0.11.2) sha256=43900b972e7301d6570f64b850a5aa67833ee7d87b458ee92805d56b7318aefe
+  rb-inotify (0.11.1) sha256=a0a700441239b0ff18eb65e3866236cd78613d6b9f78fea1f9ac47a85e47be6e
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  rouge (4.7.0) sha256=dba5896715c0325c362e895460a6d350803dbf6427454f49a47500f3193ea739
+  safe_yaml (1.0.5) sha256=a6ac2d64b7eb027bdeeca1851fe7e7af0d668e133e8a88066a0c6f7087d9f848
+  sass-embedded (1.99.0-aarch64-linux-gnu) sha256=a46615b0295ca7bd979b9ce79f6b9f1d26881736400188bd6fd5c4b7c9b46473
+  sass-embedded (1.99.0-aarch64-linux-musl) sha256=eaa6d56968909d1d54073c46e21c13fd5bbcb5af609d7e4fbe6b196426ca8e49
+  sass-embedded (1.99.0-arm-linux-gnueabihf) sha256=f5f0748934660cda6948917af6dc974caf4d36ea6121e450982153b7d9c49b55
+  sass-embedded (1.99.0-arm-linux-musleabihf) sha256=29a4056e76bc136025ba5d03e82d86ecdabfb6c07a473a4fdedcd72fb28dbbc4
+  sass-embedded (1.99.0-arm64-darwin) sha256=20773f2fb0e8f4d0194eb1874dab4c0ef60262ff6dafe29361e217beb2208629
+  sass-embedded (1.99.0-x86_64-darwin) sha256=371774c83b6dce8a2cb7b5ce5a0f918ff2735bf200b00e3bc7067366654fff13
+  sass-embedded (1.99.0-x86_64-linux-gnu) sha256=a4e2ae5e9951815cb8b3ab408cee8b800852491988a57de735f18d259c70d7c4
+  sass-embedded (1.99.0-x86_64-linux-musl) sha256=94be72a6f856c610e67b12303dc76a58412e64b24ce97bdf4912199b8145c8dd
+  sax-machine (1.3.2) sha256=a1112678039eea4c402827ca0d377744e0f882fd6386f29f7b0023d938750d3a
+  securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
+  set (1.1.3) sha256=12bbbd31c8b177d55ac0314bcc7f4c473276b06e8a2dcfdc14326e73ce7769ce
+  singleton (0.3.0) sha256=83ea1bca5f4aa34d00305ab842a7862ea5a8a11c73d362cb52379d94e9615778
+  stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
+  terminal-table (3.0.2) sha256=f951b6af5f3e00203fb290a669e0a85c5dd5b051b3b023392ccfd67ba5abae91
+  terser (1.2.7) sha256=1b12eb49769dadac44caac3485b38928ff4ab435f1bbbacfe8048cff84c6aa1b
+  time (0.4.2) sha256=f324e498c3bde9471d45a7d18f874c27980e9867aa5cfca61bebf52262bc3dab
+  tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
+  unicode-display_width (2.6.0) sha256=12279874bba6d5e4d2728cef814b19197dbb10d7a7837a869bab65da943b7f5a
+  unicode_utils (1.4.0) sha256=b922d0cf2313b6b7136ada6645ce7154ffc86418ca07d53b058efe9eb72f2a40
+  uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
+  webrick (1.9.2) sha256=beb4a15fc474defed24a3bda4ffd88a490d517c9e4e6118c3edce59e45864131
+
 BUNDLED WITH
-   2.5.7
+  4.0.10

--- a/_config.yml
+++ b/_config.yml
@@ -462,7 +462,7 @@ third_party_libraries:
     version: "5.5.0"
   google_fonts:
     url:
-      fonts: "https://fonts.googleapis.com/css?family=Roboto:300,400,500,700|Roboto+Slab:100,300,400,500,700|Material+Icons&display=swap"
+      fonts: "https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap"
   highlightjs:
     integrity:
       css:

--- a/_layouts/about.liquid
+++ b/_layouts/about.liquid
@@ -3,20 +3,18 @@ layout: default
 ---
 
 <div class="post dashboard">
-  <!-- Hero / profile panel -->
+  <!-- ============== HERO PANEL ============== -->
   <section class="panel hero-panel">
     <div class="panel-header">
       <span class="panel-icon"><i class="fa-regular fa-user"></i></span>
       <span class="panel-title">about</span>
-      <span class="panel-meta">{{ site.title }}</span>
+      <span class="panel-meta">{{ site.title | downcase }}</span>
     </div>
     <div class="panel-body">
       <div class="hero-text">
         <h1 class="post-title">
           <span class="font-weight-bold">{{ site.first_name }}</span>
-          {% if site.chinese_name %}
-            <span class="hero-cn">{{ site.chinese_name }}</span>
-          {% endif %}
+          {% if site.chinese_name %}<span class="hero-cn">{{ site.chinese_name }}</span>{% endif %}
         </h1>
         <p class="desc">{{ page.subtitle }}</p>
       </div>
@@ -32,24 +30,258 @@ layout: default
             {% capture sizes %}(min-width: {{site.max_width}}) {{ site.max_width | minus: 30 | times: 0.3}}px, (min-width: 1px) 30vw, 95vw"{% endcapture %}
             {% include figure.liquid path=profile_image_path class=profile_image_class sizes=sizes alt=page.profile.image cache_bust=true %}
           {% endif %}
-          {% if page.profile.more_info %}
-            <div class="more-info">{{ page.profile.more_info }}</div>
-          {% endif %}
         </div>
       {% endif %}
     </div>
   </section>
 
-  <!-- About content panel -->
-  <section class="panel">
+  <!-- ============== TOP CHART PANELS (publications/citations etc.) ============== -->
+  <section class="panel chart-panel">
+    <div class="panel-header">
+      <span class="panel-icon"><i class="fa-solid fa-chart-line"></i></span>
+      <span class="panel-title">Citations over time</span>
+      <span class="panel-meta">2022 — 2026</span>
+    </div>
+    <div class="panel-body">
+      <div class="y-axis">
+        <span>800</span>
+        <span>400</span>
+        <span>0</span>
+      </div>
+      <div class="chart-svg-wrap">
+        <svg class="chart" viewBox="0 0 600 70" preserveAspectRatio="none">
+          <defs>
+            <linearGradient id="cite-grad" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stop-color="#46b97f" stop-opacity="0.35"/>
+              <stop offset="100%" stop-color="#46b97f" stop-opacity="0"/>
+            </linearGradient>
+          </defs>
+          <path
+            d="M0,68 L0,62 C20,60 40,58 60,55 C90,50 110,48 140,46 C170,44 190,42 220,40 C250,38 270,38 300,36 C330,32 360,28 390,24 C420,20 450,16 480,12 C510,9 540,8 600,6 L600,68 Z"
+            fill="url(#cite-grad)" stroke="none"/>
+          <path
+            d="M0,62 C20,60 40,58 60,55 C90,50 110,48 140,46 C170,44 190,42 220,40 C250,38 270,38 300,36 C330,32 360,28 390,24 C420,20 450,16 480,12 C510,9 540,8 600,6"
+            fill="none" stroke="#2f9e6b" stroke-width="1.5"/>
+        </svg>
+      </div>
+    </div>
+  </section>
+
+  <section class="panel chart-panel">
+    <div class="panel-header">
+      <span class="panel-icon"><i class="fa-solid fa-layer-group"></i></span>
+      <span class="panel-title">Research focus by year</span>
+      <span class="panel-legend">
+        <span><span class="swatch" style="background:#2b6fb5"></span>Interpretability</span>
+        <span><span class="swatch" style="background:#d97a2c"></span>Voice / Audio</span>
+        <span><span class="swatch" style="background:#246d4d"></span>Agents</span>
+      </span>
+    </div>
+    <div class="panel-body">
+      <div class="y-axis">
+        <span>3</span>
+        <span>2</span>
+        <span>1</span>
+        <span>0</span>
+      </div>
+      <div class="chart-svg-wrap">
+        <svg class="chart chart-tall" viewBox="0 0 600 100" preserveAspectRatio="none">
+          <!-- Bottom: interpretability (blue) -->
+          <path d="M0,80 L120,80 L240,55 L360,40 L480,30 L600,32 L600,98 L0,98 Z" fill="#2b6fb5" opacity="0.78"/>
+          <!-- Middle: voice/audio (orange) -->
+          <path d="M0,75 L120,72 L240,40 L360,25 L480,18 L600,22 L600,32 L480,30 L360,40 L240,55 L120,80 L0,80 Z" fill="#d97a2c" opacity="0.78"/>
+          <!-- Top: agents (green) -->
+          <path d="M0,72 L120,68 L240,28 L360,12 L480,5 L600,8 L600,22 L480,18 L360,25 L240,40 L120,72 L0,75 Z" fill="#2f9e6b" opacity="0.78"/>
+        </svg>
+      </div>
+    </div>
+  </section>
+
+  <section class="panel chart-panel chart-bars">
+    <div class="panel-header">
+      <span class="panel-icon"><i class="fa-solid fa-code"></i></span>
+      <span class="panel-title">Lines of code edited</span>
+      <span class="panel-meta">weekly · last 52w</span>
+    </div>
+    <div class="panel-body">
+      <div class="y-axis">
+        <span>4k</span>
+        <span>2k</span>
+        <span>0</span>
+      </div>
+      <div class="chart-svg-wrap">
+        <svg class="chart" viewBox="0 0 600 95" preserveAspectRatio="none">
+          {% assign heights = "42,28,55,38,72,52,40,62,68,42,32,64,48,78,56,38,66,44,58,52,74,40,62,54,70,38,48,64,42,72,56,52,62,40,68,54,58,48,66,38,62,56,52,68,54,42,62,52,56,46,64,54" | split: "," %}
+          {% for h in heights %}
+            <rect x="{{ forloop.index0 | times: 11 | plus: 3 }}" y="{{ 88 | minus: h }}" width="8" height="{{ h }}" fill="#a06034" rx="0.5"/>
+          {% endfor %}
+        </svg>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============== RESEARCH MEMO GRID ============== -->
+  <section class="panel memo-section">
     <div class="panel-header">
       <span class="panel-icon"><i class="fa-regular fa-file-lines"></i></span>
-      <span class="panel-title">research notes</span>
+      <span class="panel-title">Research memos</span>
+      <span class="panel-meta">phd · day 0 — present</span>
+    </div>
+    <div class="panel-body">
+      <div class="memo-grid">
+        <div class="memo-card">
+          <div class="memo-head">
+            <span class="memo-tag">Learning</span>
+            <span class="memo-day">Day 14</span>
+          </div>
+          <div class="memo-body">
+            CLIP latent tokens preserve <strong>local semantics through residual stream</strong>; can retrieve text explanations without retraining.
+          </div>
+        </div>
+        <div class="memo-card memo-decision">
+          <div class="memo-head">
+            <span class="memo-tag">Decision</span>
+            <span class="memo-day">Day 49</span>
+          </div>
+          <div class="memo-body">
+            Self-interpretation beats probing for ethics/harm tracing. <strong>Scale to RLHF on hidden states.</strong>
+          </div>
+        </div>
+        <div class="memo-card memo-planning">
+          <div class="memo-head">
+            <span class="memo-tag">Planning</span>
+            <span class="memo-day">Day 92</span>
+          </div>
+          <div class="memo-body">
+            Few-shot emotion control via speaker-rep deltas. Build EmoKnob; ship demo on HuggingFace.
+          </div>
+        </div>
+        <div class="memo-card">
+          <div class="memo-head">
+            <span class="memo-tag">Learning</span>
+            <span class="memo-day">Day 126</span>
+          </div>
+          <div class="memo-body">
+            Queueing RL exploded delays past day-300; <strong>need stable benchmarks</strong>. Spin out QGym.
+          </div>
+        </div>
+      </div>
+
+      <div class="timeline" aria-hidden="true">
+        <div class="timeline-track"></div>
+        <div class="timeline-mark mark-learning" style="left: 4%"></div>
+        <div class="timeline-mark mark-decision" style="left: 18%"></div>
+        <div class="timeline-mark mark-planning" style="left: 31%"></div>
+        <div class="timeline-mark mark-learning" style="left: 45%"></div>
+        <div class="timeline-mark mark-decision" style="left: 60%"></div>
+        <div class="timeline-mark mark-planning" style="left: 73%"></div>
+        <div class="timeline-mark mark-learning" style="left: 88%"></div>
+      </div>
+
+      <div class="memo-grid">
+        <div class="memo-card memo-decision">
+          <div class="memo-head">
+            <span class="memo-tag">Decision</span>
+            <span class="memo-day">Day 154</span>
+          </div>
+          <div class="memo-body">
+            Persona-based LM simulations carry <strong>systematic biases</strong>. Frame as a "promise with a catch".
+          </div>
+        </div>
+        <div class="memo-card memo-planning">
+          <div class="memo-head">
+            <span class="memo-tag">Planning</span>
+            <span class="memo-day">Day 203</span>
+          </div>
+          <div class="memo-body">
+            Automate scientific discovery loop. Start with <strong>elastic GPU agents on Modal</strong>.
+          </div>
+        </div>
+        <div class="memo-card">
+          <div class="memo-head">
+            <span class="memo-tag">Learning</span>
+            <span class="memo-day">Day 259</span>
+          </div>
+          <div class="memo-body">
+            Inference-time editing of LLM hidden states <strong>survives finetune</strong>. Robust to prompt-injection attempts.
+          </div>
+        </div>
+        <div class="memo-card memo-decision">
+          <div class="memo-head">
+            <span class="memo-tag">Decision</span>
+            <span class="memo-day">Day 378</span>
+          </div>
+          <div class="memo-body">
+            Refocus thesis around <strong>automating organizational intelligence</strong> via interpretable agents.
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============== ABOUT NOTES (markdown content) ============== -->
+  <section class="panel">
+    <div class="panel-header">
+      <span class="panel-icon"><i class="fa-regular fa-bookmark"></i></span>
+      <span class="panel-title">notes</span>
     </div>
     <div class="panel-body">{{ content }}</div>
   </section>
 
-  <!-- Social panel -->
+  <!-- ============== EXAMPLE WORK PANELS (code-style) ============== -->
+  <div class="example-row">
+    <section class="panel code-panel">
+      <div class="panel-header">
+        <span class="panel-icon"><i class="fa-solid fa-terminal"></i></span>
+        <span class="panel-title">Example work · Self-interpretation of LLM embeddings</span>
+        <span class="panel-meta">SelfIE · ICML '24</span>
+      </div>
+      <div class="panel-body">
+<pre><span class="code-comment"># interpret a hidden state using the model itself</span>
+<span class="code-keyword">def</span> <span class="code-fn">selfie</span>(model, h, prompt=<span class="code-string">"explain this:"</span>):
+    ids = tokenize(prompt)
+    out = model(ids, inject_hidden=h, layer=<span class="code-num">14</span>)
+<span class="code-suppressed">25+ lines suppressed</span>
+    <span class="code-keyword">return</span> decode(out)
+
+<span class="code-keyword">for</span> layer <span class="code-keyword">in</span> range(<span class="code-num">12</span>, <span class="code-num">28</span>):
+    h = forward_to(layer, prompt=<span class="code-string">"How to make a bomb?"</span>)
+    print(layer, selfie(model, h))
+<span class="code-suppressed">10+ lines suppressed</span></pre>
+        <div class="code-output">
+<span class="out-title">Layer 22 · ethical refusal trace</span>{<span style="color:#9bd1f0">'reason'</span>: <span style="color:#f0c08b">'harmful_request'</span>, <span style="color:#9bd1f0">'confidence'</span>: <span style="color:#b3e0c2">0.94</span>}
+{<span style="color:#9bd1f0">'override'</span>: <span style="color:#f0c08b">'rlhf_token_inject'</span>, <span style="color:#9bd1f0">'erased'</span>: <span style="color:#b3e0c2">true</span>}
+        </div>
+      </div>
+    </section>
+
+    <section class="panel code-panel">
+      <div class="panel-header">
+        <span class="panel-icon"><i class="fa-solid fa-terminal"></i></span>
+        <span class="panel-title">Example work · Few-shot emotion control for TTS</span>
+        <span class="panel-meta">EmoKnob · EMNLP '24</span>
+      </div>
+      <div class="panel-body">
+<pre><span class="code-comment"># learn an emotion direction from few demos</span>
+<span class="code-keyword">def</span> <span class="code-fn">emotion_dir</span>(neutral, emo, alpha=<span class="code-num">1.5</span>):
+    z_n = encode(neutral)
+    z_e = encode(emo)
+    delta = (z_e - z_n).mean(<span class="code-num">0</span>)
+<span class="code-suppressed">40+ lines suppressed</span>
+    <span class="code-keyword">return</span> normalize(delta) * alpha
+
+knob = emotion_dir(neutral_clips, sad_clips, alpha=<span class="code-num">2.0</span>)
+synth = clone(text=<span class="code-string">"the rain hasn't stopped"</span>, ref=spk, knob=knob)
+<span class="code-suppressed">20+ lines suppressed</span></pre>
+        <div class="code-output">
+<span class="out-title">Subjective MOS · sadness</span>{<span style="color:#9bd1f0">'EmoKnob'</span>: <span style="color:#b3e0c2">4.21</span>, <span style="color:#9bd1f0">'commercial_baseline'</span>: <span style="color:#b3e0c2">3.46</span>}
+{<span style="color:#9bd1f0">'recognizable'</span>: <span style="color:#b3e0c2">0.88</span>, <span style="color:#9bd1f0">'faithful_speaker'</span>: <span style="color:#b3e0c2">0.92</span>}
+        </div>
+      </div>
+    </section>
+  </div>
+
+  <!-- ============== CONNECT ============== -->
   {% if page.social %}
     <section class="panel">
       <div class="panel-header">
@@ -59,15 +291,13 @@ layout: default
       <div class="panel-body">
         <div class="social">
           <div class="contact-icons">{% include social.liquid %}</div>
-          {% if site.contact_note %}
-            <div class="contact-note">{{ site.contact_note }}</div>
-          {% endif %}
+          {% if site.contact_note %}<div class="contact-note">{{ site.contact_note }}</div>{% endif %}
         </div>
       </div>
     </section>
   {% endif %}
 
-  <!-- News panel -->
+  <!-- ============== NEWS ============== -->
   {% if page.news and site.announcements.enabled %}
     <section class="panel">
       <div class="panel-header">
@@ -78,7 +308,7 @@ layout: default
     </section>
   {% endif %}
 
-  <!-- Latest posts panel -->
+  <!-- ============== LATEST POSTS ============== -->
   {% if site.latest_posts.enabled %}
     <section class="panel">
       <div class="panel-header">
@@ -89,7 +319,7 @@ layout: default
     </section>
   {% endif %}
 
-  <!-- Selected papers panel -->
+  <!-- ============== PUBLICATIONS ============== -->
   {% if page.selected_papers %}
     <section class="panel panel-flush">
       <div class="panel-header">

--- a/_layouts/about.liquid
+++ b/_layouts/about.liquid
@@ -1,80 +1,107 @@
 ---
 layout: default
 ---
-<div class="post">
-<header class="post-header">
-  <div class="header-content" style="display: flex; align-items: center; justify-content: space-between;">
-    <div class="title-and-subtitle">
-      <h1 class="post-title">
-          <span class="font-weight-bold">{{ site.first_name }}</span> <br>
-          {{ site.chinese_name }}
-      </h1>
-      <p class="desc">{{ page.subtitle }}</p>
+
+<div class="post dashboard">
+  <!-- Hero / profile panel -->
+  <section class="panel hero-panel">
+    <div class="panel-header">
+      <span class="panel-icon"><i class="fa-regular fa-user"></i></span>
+      <span class="panel-title">about</span>
+      <span class="panel-meta">{{ site.title }}</span>
     </div>
-    {% if page.profile %}
-    <div class="profile" style="flex-shrink: 0">
-      {% if page.profile.image %}
-        {% assign profile_image_path = page.profile.image | prepend: 'assets/img/' %}
-        {% if page.profile.image_circular %}
-          {% assign profile_image_class = 'img-fluid z-depth-1 rounded-circle' %}
-        {% else %}
-          {% assign profile_image_class = 'img-fluid z-depth-1 rounded' %}
-        {% endif %}
-        {% capture sizes %}(min-width: {{site.max_width}}) {{ site.max_width | minus: 30 | times: 0.3}}px, (min-width: 1px)
-        30vw, 95vw"{% endcapture %}
-        {%
-          include figure.liquid path = profile_image_path class = profile_image_class sizes = sizes alt = page.profile.image
-          cache_bust = true
-        %}
-      {% endif %}
-      {% if page.profile.more_info %}
-        <div class="more-info">{{ page.profile.more_info }}</div>
-      {% endif %}
-    </div>
-    {% endif %}
-  </div>
-</header>
-
-
-  <article>
-
-    <div class="clearfix">{{ content }}</div>
-       <!-- Social -->
-    {% if page.social %}
-      <div class="social">
-        <div class="contact-icons">{% include social.liquid %}</div>
-
-        <div class="contact-note">{{ site.contact_note }}</div>
+    <div class="panel-body">
+      <div class="hero-text">
+        <h1 class="post-title">
+          <span class="font-weight-bold">{{ site.first_name }}</span>
+          {% if site.chinese_name %}
+            <span class="hero-cn">{{ site.chinese_name }}</span>
+          {% endif %}
+        </h1>
+        <p class="desc">{{ page.subtitle }}</p>
       </div>
-    {% endif %}
-    <!-- News -->
-    {% if page.news and site.announcements.enabled %}
-      <h2>
-        <a href="{{ '/news/' | relative_url }}" style="color: inherit">news</a>
-      </h2>
-      {% include news.liquid limit=true %}
-    {% endif %}
+      {% if page.profile %}
+        <div class="hero-photo">
+          {% if page.profile.image %}
+            {% assign profile_image_path = page.profile.image | prepend: 'assets/img/' %}
+            {% if page.profile.image_circular %}
+              {% assign profile_image_class = 'img-fluid z-depth-1 rounded-circle' %}
+            {% else %}
+              {% assign profile_image_class = 'img-fluid z-depth-1 rounded' %}
+            {% endif %}
+            {% capture sizes %}(min-width: {{site.max_width}}) {{ site.max_width | minus: 30 | times: 0.3}}px, (min-width: 1px) 30vw, 95vw"{% endcapture %}
+            {% include figure.liquid path=profile_image_path class=profile_image_class sizes=sizes alt=page.profile.image cache_bust=true %}
+          {% endif %}
+          {% if page.profile.more_info %}
+            <div class="more-info">{{ page.profile.more_info }}</div>
+          {% endif %}
+        </div>
+      {% endif %}
+    </div>
+  </section>
 
-    <!-- Latest posts -->
-    {% if site.latest_posts.enabled %}
-      <h2>
-        <a href="{{ '/blog/' | relative_url }}" style="color: inherit">latest posts</a>
-      </h2>
-      {% include latest_posts.liquid %}
-    {% endif %}
+  <!-- About content panel -->
+  <section class="panel">
+    <div class="panel-header">
+      <span class="panel-icon"><i class="fa-regular fa-file-lines"></i></span>
+      <span class="panel-title">research notes</span>
+    </div>
+    <div class="panel-body">{{ content }}</div>
+  </section>
 
-    <!-- Selected papers -->
-    {% if page.selected_papers %}
-      <h2>
-        publications
-      </h2>
-      {% include selected_papers.liquid %}
-    {% endif %}
+  <!-- Social panel -->
+  {% if page.social %}
+    <section class="panel">
+      <div class="panel-header">
+        <span class="panel-icon"><i class="fa-regular fa-compass"></i></span>
+        <span class="panel-title">connect</span>
+      </div>
+      <div class="panel-body">
+        <div class="social">
+          <div class="contact-icons">{% include social.liquid %}</div>
+          {% if site.contact_note %}
+            <div class="contact-note">{{ site.contact_note }}</div>
+          {% endif %}
+        </div>
+      </div>
+    </section>
+  {% endif %}
 
-  
+  <!-- News panel -->
+  {% if page.news and site.announcements.enabled %}
+    <section class="panel">
+      <div class="panel-header">
+        <span class="panel-icon"><i class="fa-regular fa-newspaper"></i></span>
+        <span class="panel-title"><a href="{{ '/news/' | relative_url }}" style="color: inherit; text-decoration: none">news</a></span>
+      </div>
+      <div class="panel-body">{% include news.liquid limit=true %}</div>
+    </section>
+  {% endif %}
 
-    {% if site.newsletter.enabled and site.footer_fixed %}
-      {% include scripts/newsletter.liquid center=true %}
-    {% endif %}
-  </article>
+  <!-- Latest posts panel -->
+  {% if site.latest_posts.enabled %}
+    <section class="panel">
+      <div class="panel-header">
+        <span class="panel-icon"><i class="fa-regular fa-comment"></i></span>
+        <span class="panel-title"><a href="{{ '/blog/' | relative_url }}" style="color: inherit; text-decoration: none">latest posts</a></span>
+      </div>
+      <div class="panel-body">{% include latest_posts.liquid %}</div>
+    </section>
+  {% endif %}
+
+  <!-- Selected papers panel -->
+  {% if page.selected_papers %}
+    <section class="panel panel-flush">
+      <div class="panel-header">
+        <span class="panel-icon"><i class="fa-regular fa-bookmark"></i></span>
+        <span class="panel-title">publications</span>
+        <span class="panel-meta">selected</span>
+      </div>
+      <div class="panel-body">{% include selected_papers.liquid %}</div>
+    </section>
+  {% endif %}
+
+  {% if site.newsletter.enabled and site.footer_fixed %}
+    {% include scripts/newsletter.liquid center=true %}
+  {% endif %}
 </div>

--- a/_layouts/about.liquid
+++ b/_layouts/about.liquid
@@ -3,7 +3,7 @@ layout: default
 ---
 
 <div class="post dashboard">
-  <!-- ============== HERO PANEL ============== -->
+  <!-- Hero / profile panel -->
   <section class="panel hero-panel">
     <div class="panel-header">
       <span class="panel-icon"><i class="fa-regular fa-user"></i></span>
@@ -30,258 +30,22 @@ layout: default
             {% capture sizes %}(min-width: {{site.max_width}}) {{ site.max_width | minus: 30 | times: 0.3}}px, (min-width: 1px) 30vw, 95vw"{% endcapture %}
             {% include figure.liquid path=profile_image_path class=profile_image_class sizes=sizes alt=page.profile.image cache_bust=true %}
           {% endif %}
+          {% if page.profile.more_info %}<div class="more-info">{{ page.profile.more_info }}</div>{% endif %}
         </div>
       {% endif %}
     </div>
   </section>
 
-  <!-- ============== TOP CHART PANELS (publications/citations etc.) ============== -->
-  <section class="panel chart-panel">
-    <div class="panel-header">
-      <span class="panel-icon"><i class="fa-solid fa-chart-line"></i></span>
-      <span class="panel-title">Citations over time</span>
-      <span class="panel-meta">2022 — 2026</span>
-    </div>
-    <div class="panel-body">
-      <div class="y-axis">
-        <span>800</span>
-        <span>400</span>
-        <span>0</span>
-      </div>
-      <div class="chart-svg-wrap">
-        <svg class="chart" viewBox="0 0 600 70" preserveAspectRatio="none">
-          <defs>
-            <linearGradient id="cite-grad" x1="0" y1="0" x2="0" y2="1">
-              <stop offset="0%" stop-color="#46b97f" stop-opacity="0.35"/>
-              <stop offset="100%" stop-color="#46b97f" stop-opacity="0"/>
-            </linearGradient>
-          </defs>
-          <path
-            d="M0,68 L0,62 C20,60 40,58 60,55 C90,50 110,48 140,46 C170,44 190,42 220,40 C250,38 270,38 300,36 C330,32 360,28 390,24 C420,20 450,16 480,12 C510,9 540,8 600,6 L600,68 Z"
-            fill="url(#cite-grad)" stroke="none"/>
-          <path
-            d="M0,62 C20,60 40,58 60,55 C90,50 110,48 140,46 C170,44 190,42 220,40 C250,38 270,38 300,36 C330,32 360,28 390,24 C420,20 450,16 480,12 C510,9 540,8 600,6"
-            fill="none" stroke="#2f9e6b" stroke-width="1.5"/>
-        </svg>
-      </div>
-    </div>
-  </section>
-
-  <section class="panel chart-panel">
-    <div class="panel-header">
-      <span class="panel-icon"><i class="fa-solid fa-layer-group"></i></span>
-      <span class="panel-title">Research focus by year</span>
-      <span class="panel-legend">
-        <span><span class="swatch" style="background:#2b6fb5"></span>Interpretability</span>
-        <span><span class="swatch" style="background:#d97a2c"></span>Voice / Audio</span>
-        <span><span class="swatch" style="background:#246d4d"></span>Agents</span>
-      </span>
-    </div>
-    <div class="panel-body">
-      <div class="y-axis">
-        <span>3</span>
-        <span>2</span>
-        <span>1</span>
-        <span>0</span>
-      </div>
-      <div class="chart-svg-wrap">
-        <svg class="chart chart-tall" viewBox="0 0 600 100" preserveAspectRatio="none">
-          <!-- Bottom: interpretability (blue) -->
-          <path d="M0,80 L120,80 L240,55 L360,40 L480,30 L600,32 L600,98 L0,98 Z" fill="#2b6fb5" opacity="0.78"/>
-          <!-- Middle: voice/audio (orange) -->
-          <path d="M0,75 L120,72 L240,40 L360,25 L480,18 L600,22 L600,32 L480,30 L360,40 L240,55 L120,80 L0,80 Z" fill="#d97a2c" opacity="0.78"/>
-          <!-- Top: agents (green) -->
-          <path d="M0,72 L120,68 L240,28 L360,12 L480,5 L600,8 L600,22 L480,18 L360,25 L240,40 L120,72 L0,75 Z" fill="#2f9e6b" opacity="0.78"/>
-        </svg>
-      </div>
-    </div>
-  </section>
-
-  <section class="panel chart-panel chart-bars">
-    <div class="panel-header">
-      <span class="panel-icon"><i class="fa-solid fa-code"></i></span>
-      <span class="panel-title">Lines of code edited</span>
-      <span class="panel-meta">weekly · last 52w</span>
-    </div>
-    <div class="panel-body">
-      <div class="y-axis">
-        <span>4k</span>
-        <span>2k</span>
-        <span>0</span>
-      </div>
-      <div class="chart-svg-wrap">
-        <svg class="chart" viewBox="0 0 600 95" preserveAspectRatio="none">
-          {% assign heights = "42,28,55,38,72,52,40,62,68,42,32,64,48,78,56,38,66,44,58,52,74,40,62,54,70,38,48,64,42,72,56,52,62,40,68,54,58,48,66,38,62,56,52,68,54,42,62,52,56,46,64,54" | split: "," %}
-          {% for h in heights %}
-            <rect x="{{ forloop.index0 | times: 11 | plus: 3 }}" y="{{ 88 | minus: h }}" width="8" height="{{ h }}" fill="#a06034" rx="0.5"/>
-          {% endfor %}
-        </svg>
-      </div>
-    </div>
-  </section>
-
-  <!-- ============== RESEARCH MEMO GRID ============== -->
-  <section class="panel memo-section">
-    <div class="panel-header">
-      <span class="panel-icon"><i class="fa-regular fa-file-lines"></i></span>
-      <span class="panel-title">Research memos</span>
-      <span class="panel-meta">phd · day 0 — present</span>
-    </div>
-    <div class="panel-body">
-      <div class="memo-grid">
-        <div class="memo-card">
-          <div class="memo-head">
-            <span class="memo-tag">Learning</span>
-            <span class="memo-day">Day 14</span>
-          </div>
-          <div class="memo-body">
-            CLIP latent tokens preserve <strong>local semantics through residual stream</strong>; can retrieve text explanations without retraining.
-          </div>
-        </div>
-        <div class="memo-card memo-decision">
-          <div class="memo-head">
-            <span class="memo-tag">Decision</span>
-            <span class="memo-day">Day 49</span>
-          </div>
-          <div class="memo-body">
-            Self-interpretation beats probing for ethics/harm tracing. <strong>Scale to RLHF on hidden states.</strong>
-          </div>
-        </div>
-        <div class="memo-card memo-planning">
-          <div class="memo-head">
-            <span class="memo-tag">Planning</span>
-            <span class="memo-day">Day 92</span>
-          </div>
-          <div class="memo-body">
-            Few-shot emotion control via speaker-rep deltas. Build EmoKnob; ship demo on HuggingFace.
-          </div>
-        </div>
-        <div class="memo-card">
-          <div class="memo-head">
-            <span class="memo-tag">Learning</span>
-            <span class="memo-day">Day 126</span>
-          </div>
-          <div class="memo-body">
-            Queueing RL exploded delays past day-300; <strong>need stable benchmarks</strong>. Spin out QGym.
-          </div>
-        </div>
-      </div>
-
-      <div class="timeline" aria-hidden="true">
-        <div class="timeline-track"></div>
-        <div class="timeline-mark mark-learning" style="left: 4%"></div>
-        <div class="timeline-mark mark-decision" style="left: 18%"></div>
-        <div class="timeline-mark mark-planning" style="left: 31%"></div>
-        <div class="timeline-mark mark-learning" style="left: 45%"></div>
-        <div class="timeline-mark mark-decision" style="left: 60%"></div>
-        <div class="timeline-mark mark-planning" style="left: 73%"></div>
-        <div class="timeline-mark mark-learning" style="left: 88%"></div>
-      </div>
-
-      <div class="memo-grid">
-        <div class="memo-card memo-decision">
-          <div class="memo-head">
-            <span class="memo-tag">Decision</span>
-            <span class="memo-day">Day 154</span>
-          </div>
-          <div class="memo-body">
-            Persona-based LM simulations carry <strong>systematic biases</strong>. Frame as a "promise with a catch".
-          </div>
-        </div>
-        <div class="memo-card memo-planning">
-          <div class="memo-head">
-            <span class="memo-tag">Planning</span>
-            <span class="memo-day">Day 203</span>
-          </div>
-          <div class="memo-body">
-            Automate scientific discovery loop. Start with <strong>elastic GPU agents on Modal</strong>.
-          </div>
-        </div>
-        <div class="memo-card">
-          <div class="memo-head">
-            <span class="memo-tag">Learning</span>
-            <span class="memo-day">Day 259</span>
-          </div>
-          <div class="memo-body">
-            Inference-time editing of LLM hidden states <strong>survives finetune</strong>. Robust to prompt-injection attempts.
-          </div>
-        </div>
-        <div class="memo-card memo-decision">
-          <div class="memo-head">
-            <span class="memo-tag">Decision</span>
-            <span class="memo-day">Day 378</span>
-          </div>
-          <div class="memo-body">
-            Refocus thesis around <strong>automating organizational intelligence</strong> via interpretable agents.
-          </div>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <!-- ============== ABOUT NOTES (markdown content) ============== -->
+  <!-- Markdown content -->
   <section class="panel">
     <div class="panel-header">
-      <span class="panel-icon"><i class="fa-regular fa-bookmark"></i></span>
-      <span class="panel-title">notes</span>
+      <span class="panel-icon"><i class="fa-regular fa-file-lines"></i></span>
+      <span class="panel-title">research notes</span>
     </div>
     <div class="panel-body">{{ content }}</div>
   </section>
 
-  <!-- ============== EXAMPLE WORK PANELS (code-style) ============== -->
-  <div class="example-row">
-    <section class="panel code-panel">
-      <div class="panel-header">
-        <span class="panel-icon"><i class="fa-solid fa-terminal"></i></span>
-        <span class="panel-title">Example work · Self-interpretation of LLM embeddings</span>
-        <span class="panel-meta">SelfIE · ICML '24</span>
-      </div>
-      <div class="panel-body">
-<pre><span class="code-comment"># interpret a hidden state using the model itself</span>
-<span class="code-keyword">def</span> <span class="code-fn">selfie</span>(model, h, prompt=<span class="code-string">"explain this:"</span>):
-    ids = tokenize(prompt)
-    out = model(ids, inject_hidden=h, layer=<span class="code-num">14</span>)
-<span class="code-suppressed">25+ lines suppressed</span>
-    <span class="code-keyword">return</span> decode(out)
-
-<span class="code-keyword">for</span> layer <span class="code-keyword">in</span> range(<span class="code-num">12</span>, <span class="code-num">28</span>):
-    h = forward_to(layer, prompt=<span class="code-string">"How to make a bomb?"</span>)
-    print(layer, selfie(model, h))
-<span class="code-suppressed">10+ lines suppressed</span></pre>
-        <div class="code-output">
-<span class="out-title">Layer 22 · ethical refusal trace</span>{<span style="color:#9bd1f0">'reason'</span>: <span style="color:#f0c08b">'harmful_request'</span>, <span style="color:#9bd1f0">'confidence'</span>: <span style="color:#b3e0c2">0.94</span>}
-{<span style="color:#9bd1f0">'override'</span>: <span style="color:#f0c08b">'rlhf_token_inject'</span>, <span style="color:#9bd1f0">'erased'</span>: <span style="color:#b3e0c2">true</span>}
-        </div>
-      </div>
-    </section>
-
-    <section class="panel code-panel">
-      <div class="panel-header">
-        <span class="panel-icon"><i class="fa-solid fa-terminal"></i></span>
-        <span class="panel-title">Example work · Few-shot emotion control for TTS</span>
-        <span class="panel-meta">EmoKnob · EMNLP '24</span>
-      </div>
-      <div class="panel-body">
-<pre><span class="code-comment"># learn an emotion direction from few demos</span>
-<span class="code-keyword">def</span> <span class="code-fn">emotion_dir</span>(neutral, emo, alpha=<span class="code-num">1.5</span>):
-    z_n = encode(neutral)
-    z_e = encode(emo)
-    delta = (z_e - z_n).mean(<span class="code-num">0</span>)
-<span class="code-suppressed">40+ lines suppressed</span>
-    <span class="code-keyword">return</span> normalize(delta) * alpha
-
-knob = emotion_dir(neutral_clips, sad_clips, alpha=<span class="code-num">2.0</span>)
-synth = clone(text=<span class="code-string">"the rain hasn't stopped"</span>, ref=spk, knob=knob)
-<span class="code-suppressed">20+ lines suppressed</span></pre>
-        <div class="code-output">
-<span class="out-title">Subjective MOS · sadness</span>{<span style="color:#9bd1f0">'EmoKnob'</span>: <span style="color:#b3e0c2">4.21</span>, <span style="color:#9bd1f0">'commercial_baseline'</span>: <span style="color:#b3e0c2">3.46</span>}
-{<span style="color:#9bd1f0">'recognizable'</span>: <span style="color:#b3e0c2">0.88</span>, <span style="color:#9bd1f0">'faithful_speaker'</span>: <span style="color:#b3e0c2">0.92</span>}
-        </div>
-      </div>
-    </section>
-  </div>
-
-  <!-- ============== CONNECT ============== -->
+  <!-- Connect -->
   {% if page.social %}
     <section class="panel">
       <div class="panel-header">
@@ -297,7 +61,7 @@ synth = clone(text=<span class="code-string">"the rain hasn't stopped"</span>, r
     </section>
   {% endif %}
 
-  <!-- ============== NEWS ============== -->
+  <!-- News -->
   {% if page.news and site.announcements.enabled %}
     <section class="panel">
       <div class="panel-header">
@@ -308,7 +72,7 @@ synth = clone(text=<span class="code-string">"the rain hasn't stopped"</span>, r
     </section>
   {% endif %}
 
-  <!-- ============== LATEST POSTS ============== -->
+  <!-- Latest posts -->
   {% if site.latest_posts.enabled %}
     <section class="panel">
       <div class="panel-header">
@@ -319,7 +83,7 @@ synth = clone(text=<span class="code-string">"the rain hasn't stopped"</span>, r
     </section>
   {% endif %}
 
-  <!-- ============== PUBLICATIONS ============== -->
+  <!-- Publications -->
   {% if page.selected_papers %}
     <section class="panel panel-flush">
       <div class="panel-header">

--- a/_layouts/page.liquid
+++ b/_layouts/page.liquid
@@ -9,21 +9,27 @@ layout: default
 {% endif %}
 
 <div class="post">
-  <header class="post-header">
-    <h1 class="post-title">{{ page.title }}</h1>
-    <p class="post-description">{{ page.description }}</p>
-  </header>
-
-  <article>
-    {{ content }}
-  </article>
-
-  {% if page.related_publications %}
-    <h2>References</h2>
-    <div class="publications">
-      {% bibliography --cited_in_order %}
+  <section class="panel">
+    <div class="panel-header">
+      <span class="panel-icon"><i class="fa-regular fa-file-lines"></i></span>
+      <span class="panel-title">{{ page.title }}</span>
+      {% if page.description %}
+        <span class="panel-meta">{{ page.description }}</span>
+      {% endif %}
     </div>
-  {% endif %}
+    <div class="panel-body">
+      <article>
+        {{ content }}
+      </article>
+
+      {% if page.related_publications %}
+        <h2>References</h2>
+        <div class="publications">
+          {% bibliography --cited_in_order %}
+        </div>
+      {% endif %}
+    </div>
+  </section>
 
   {% if site.giscus and page.giscus_comments %}
     {% include giscus.liquid %}

--- a/_layouts/post.liquid
+++ b/_layouts/post.liquid
@@ -15,74 +15,80 @@ layout: default
 {% assign url_beginning = page.url | slice: 0, 6 %}
 
 <div class="post">
-  <header class="post-header">
-    <h1 class="post-title">{{ page.title }}</h1>
-    <p class="post-meta">
-      Created in {{ page.date | date: '%B %d, %Y' }}
-      {% if page.author %}by {{ page.author }}{% endif %}
-      {% if page.last_updated %}, last updated in {{ page.last_updated | date: '%B %d, %Y' }}{% endif %}
-      {% if page.meta %}• {{ page.meta }}{% endif %}
-    </p>
-    <p class="post-tags">
-      {% if url_beginning == '/blog/' %}
-        <a href="{{ year | prepend: '/blog/' | prepend: site.baseurl}}"> <i class="fa-solid fa-calendar fa-sm"></i> {{ year }} </a>
-      {% else %}
-        <i class="fa-solid fa-calendar fa-sm"></i> {{ year }}
-      {% endif %}
-      {% if tags != '' %}
-        &nbsp; &middot; &nbsp;
-        {% for tag in page.tags %}
-          {% if url_beginning == '/blog/' %}
-            <a href="{{ tag | slugify | prepend: '/blog/tag/' | prepend: site.baseurl}}"> <i class="fa-solid fa-hashtag fa-sm"></i> {{ tag }}</a>
-          {% else %}
-            <i class="fa-solid fa-hashtag fa-sm"></i> {{ tag }}
-          {% endif %}
-          {% unless forloop.last %}
-            &nbsp;
-          {% endunless %}
-        {% endfor %}
-      {% endif %}
-
-      {% if categories != '' %}
-        &nbsp; &middot; &nbsp;
-        {% for category in page.categories %}
-          {% if url_beginning == '/blog/' %}
-            <a href="{{ category | slugify | prepend: '/blog/category/' | prepend: site.baseurl}}">
-              <i class="fa-solid fa-tag fa-sm"></i> {{ category -}}
-            </a>
-          {% else %}
-            <i class="fa-solid fa-tag fa-sm"></i> {{ category }}
-          {% endif %}
-          {% unless forloop.last %}
-            &nbsp;
-          {% endunless %}
-        {% endfor %}
-      {% endif %}
-    </p>
-  </header>
-
-  <article class="post-content">
-    {% if page.toc and page.toc.beginning %}
-      <div id="table-of-contents">
-        {% toc %}
-      </div>
-      <hr>
-    {% endif %}
-    <div id="markdown-content">
-      {{ content }}
+  <section class="panel">
+    <div class="panel-header">
+      <span class="panel-icon"><i class="fa-regular fa-file-lines"></i></span>
+      <span class="panel-title">{{ page.title }}</span>
+      <span class="panel-meta">{{ page.date | date: '%b %d, %Y' }}</span>
     </div>
-  </article>
+    <div class="panel-body">
+      <p class="post-meta" style="margin-bottom: 0.4rem;">
+        Created in {{ page.date | date: '%B %d, %Y' }}
+        {% if page.author %}by {{ page.author }}{% endif %}
+        {% if page.last_updated %}, last updated in {{ page.last_updated | date: '%B %d, %Y' }}{% endif %}
+        {% if page.meta %}• {{ page.meta }}{% endif %}
+      </p>
+      <p class="post-tags">
+        {% if url_beginning == '/blog/' %}
+          <a href="{{ year | prepend: '/blog/' | prepend: site.baseurl}}"> <i class="fa-solid fa-calendar fa-sm"></i> {{ year }} </a>
+        {% else %}
+          <i class="fa-solid fa-calendar fa-sm"></i> {{ year }}
+        {% endif %}
+        {% if tags != '' %}
+          &nbsp; &middot; &nbsp;
+          {% for tag in page.tags %}
+            {% if url_beginning == '/blog/' %}
+              <a href="{{ tag | slugify | prepend: '/blog/tag/' | prepend: site.baseurl}}"> <i class="fa-solid fa-hashtag fa-sm"></i> {{ tag }}</a>
+            {% else %}
+              <i class="fa-solid fa-hashtag fa-sm"></i> {{ tag }}
+            {% endif %}
+            {% unless forloop.last %}
+              &nbsp;
+            {% endunless %}
+          {% endfor %}
+        {% endif %}
 
-  {% if page.citation %}
-    {% include citation.liquid %}
-  {% endif %}
+        {% if categories != '' %}
+          &nbsp; &middot; &nbsp;
+          {% for category in page.categories %}
+            {% if url_beginning == '/blog/' %}
+              <a href="{{ category | slugify | prepend: '/blog/category/' | prepend: site.baseurl}}">
+                <i class="fa-solid fa-tag fa-sm"></i> {{ category -}}
+              </a>
+            {% else %}
+              <i class="fa-solid fa-tag fa-sm"></i> {{ category }}
+            {% endif %}
+            {% unless forloop.last %}
+              &nbsp;
+            {% endunless %}
+          {% endfor %}
+        {% endif %}
+      </p>
 
-  {% if page.related_publications %}
-    <h2>References</h2>
-    <div class="publications">
-      {% bibliography --cited_in_order %}
+      <article class="post-content">
+        {% if page.toc and page.toc.beginning %}
+          <div id="table-of-contents">
+            {% toc %}
+          </div>
+          <hr>
+        {% endif %}
+        <div id="markdown-content">
+          {{ content }}
+        </div>
+      </article>
+
+      {% if page.citation %}
+        {% include citation.liquid %}
+      {% endif %}
+
+      {% if page.related_publications %}
+        <h2>References</h2>
+        <div class="publications">
+          {% bibliography --cited_in_order %}
+        </div>
+      {% endif %}
     </div>
-  {% endif %}
+  </section>
 
   {% if site.related_blog_posts.enabled %}
     {% if page.related_posts == null or page.related_posts %}

--- a/_pages/blog.md
+++ b/_pages/blog.md
@@ -18,6 +18,14 @@ pagination:
 
 <div class="post">
 
+<section class="panel">
+  <div class="panel-header">
+    <span class="panel-icon"><i class="fa-regular fa-comment"></i></span>
+    <span class="panel-title">blog</span>
+    <span class="panel-meta">posts &amp; notes</span>
+  </div>
+  <div class="panel-body">
+
 {% assign blog_name_size = site.blog_name | size %}
 {% assign blog_description_size = site.blog_description | size %}
 
@@ -193,4 +201,6 @@ pagination:
 {% include pagination.liquid %}
 {% endif %}
 
+  </div>
+</section>
 </div>

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -3,6 +3,31 @@
  ******************************************************************************/
 
 // Typography
+html,
+body {
+  font-family:
+    "Inter",
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto,
+    "Helvetica Neue",
+    Arial,
+    sans-serif;
+  font-feature-settings: "ss01", "cv11";
+}
+
+code,
+kbd,
+pre,
+samp {
+  font-family:
+    "JetBrains Mono",
+    "SFMono-Regular",
+    "Menlo",
+    "Consolas",
+    monospace;
+}
 
 p,
 h1,
@@ -17,6 +42,16 @@ li,
 span,
 strong {
   color: var(--global-text-color);
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-weight: 600;
+  letter-spacing: -0.005em;
 }
 
 hr {
@@ -247,7 +282,19 @@ ul.task-list input[type="checkbox"] {
   box-shadow: none;
   border-bottom: 1px solid var(--global-divider-color);
   background-color: var(--global-bg-color);
-  opacity: 0.95;
+  opacity: 1;
+  font-size: 0.95rem;
+
+  .navbar-brand {
+    font-weight: 600;
+    letter-spacing: -0.01em;
+  }
+
+  .navbar-nav .nav-item .nav-link {
+    font-weight: 500;
+    padding-left: 0.85rem !important;
+    padding-right: 0.85rem !important;
+  }
 }
 
 .navbar .dropdown-menu {

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -31,6 +31,15 @@ body.sticky-bottom-footer {
   max-width: $max-content-width;
 }
 
+// Slightly tighter top spacing for the dashboard look
+body.fixed-top-nav {
+  padding-top: 50px;
+}
+
+.container.mt-5 {
+  margin-top: 1.25rem !important;
+}
+
 // Profile
 .profile {
   img {

--- a/_sass/_panels.scss
+++ b/_sass/_panels.scss
@@ -257,11 +257,40 @@
 .panel .publications {
   margin-top: 0;
 
+  > h1,
+  > h2.bibliography {
+    display: none;
+  }
+
   ol.bibliography {
     > li {
       padding: 0.85rem 1.15rem;
       border-bottom: 1px solid var(--global-panel-border-color);
       margin-bottom: 0;
+      display: flex;
+      gap: 0.85rem;
+      align-items: flex-start;
+
+      > .col-sm-2 {
+        flex: 0 0 80px;
+        max-width: 80px;
+        padding: 0;
+      }
+
+      > .col-sm-8,
+      > .col-sm-10 {
+        flex: 1 1 auto;
+        max-width: none;
+        padding: 0;
+      }
+
+      img.preview {
+        width: 100%;
+        height: 56px;
+        object-fit: cover;
+        border-radius: 6px;
+        border: 1px solid var(--global-panel-border-color);
+      }
 
       &:last-child {
         border-bottom: 0;
@@ -458,6 +487,62 @@
     li {
       margin-bottom: 0.25rem;
     }
+  }
+}
+
+// Blog post-list inside a panel
+.panel .post-list {
+  margin-bottom: 0;
+
+  > li {
+    border-bottom: 1px solid var(--global-panel-border-color);
+    padding-top: 0.85rem;
+    padding-bottom: 0.85rem;
+
+    &:last-child {
+      border-bottom: 0;
+      padding-bottom: 0;
+    }
+
+    &:first-child {
+      padding-top: 0;
+    }
+
+    h3 {
+      font-size: 1.05rem;
+      font-weight: 600;
+      margin-bottom: 0.25rem;
+    }
+
+    p {
+      font-size: 0.9rem;
+      color: var(--global-text-color-light);
+      margin-bottom: 0.35rem;
+    }
+
+    .post-meta,
+    .post-tags {
+      font-size: 0.8rem;
+      color: var(--global-text-color-muted);
+    }
+  }
+}
+
+.panel .header-bar {
+  border-bottom: 0;
+  padding-top: 0;
+  padding-bottom: 0.75rem;
+  text-align: left;
+
+  h1 {
+    font-size: 1.15rem;
+    color: var(--global-text-color);
+    font-weight: 600;
+  }
+  h2 {
+    font-size: 0.92rem;
+    color: var(--global-text-color-light);
+    margin: 0;
   }
 }
 

--- a/_sass/_panels.scss
+++ b/_sass/_panels.scss
@@ -243,7 +243,7 @@ img.z-depth-1,
         font-size: 0.88rem;
         color: var(--global-text-color);
         padding: 0.42rem 0.6rem 0.42rem 0;
-        border-color: var(--global-panel-border-color);
+        border-color: var(--global-panel-inner-border-color);
         line-height: 1.45;
       }
 
@@ -281,15 +281,15 @@ img.z-depth-1,
   ol.bibliography {
     > li {
       padding: 0.7rem 1rem;
-      border-bottom: 1px solid var(--global-panel-border-color);
+      border-bottom: 1px solid var(--global-panel-inner-border-color);
       margin-bottom: 0;
       display: flex;
       gap: 0.85rem;
       align-items: flex-start;
 
       > .col-sm-2 {
-        flex: 0 0 72px;
-        max-width: 72px;
+        flex: 0 0 110px;
+        max-width: 110px;
         padding: 0;
       }
 
@@ -301,12 +301,29 @@ img.z-depth-1,
         font-size: 0.88rem;
       }
 
-      img.preview {
+      figure.preview,
+      .preview {
         width: 100%;
-        height: 50px;
+        max-width: 110px;
+        margin: 0 0 0.45rem 0;
+      }
+
+      figure.preview picture,
+      figure.preview img,
+      img.preview {
+        display: block;
+        width: 100%;
+        height: 80px;
+        max-height: 80px;
         object-fit: cover;
         border-radius: 4px;
         border: 1px solid var(--global-panel-border-color);
+        background: var(--global-panel-header-bg);
+      }
+
+      figure.preview picture img {
+        border: 0;
+        border-radius: 0;
       }
 
       &:last-child {
@@ -378,7 +395,7 @@ img.z-depth-1,
   margin-bottom: 0;
 
   > li {
-    border-bottom: 1px solid var(--global-panel-border-color);
+    border-bottom: 1px solid var(--global-panel-inner-border-color);
     padding-top: 0.7rem;
     padding-bottom: 0.7rem;
 

--- a/_sass/_panels.scss
+++ b/_sass/_panels.scss
@@ -455,13 +455,99 @@ img.z-depth-1,
 }
 
 // =================== Responsive ===================
-@media (max-width: 575px) {
+@media (max-width: 767px) {
+  .panel {
+    margin-bottom: 12px;
+  }
+
+  .panel > .panel-header {
+    padding: 0.4rem 0.65rem;
+    font-size: 0.85rem;
+  }
+
+  .panel > .panel-body {
+    padding: 0.75rem 0.85rem;
+  }
+
+  // Hero — stack with photo above the text, but keep photo a sensible size
   .panel.hero-panel > .panel-body {
     flex-direction: column-reverse;
-    align-items: stretch;
+    align-items: flex-start;
+    gap: 0.85rem;
+    padding: 0.85rem 0.85rem;
   }
   .panel.hero-panel .hero-photo {
-    width: 110px;
+    width: 96px;
     align-self: flex-start;
+  }
+  .panel.hero-panel .hero-photo img {
+    height: auto;
+  }
+  .panel.hero-panel .hero-text h1.post-title {
+    font-size: 1.4rem;
+  }
+  .hero-cn {
+    font-size: 1rem;
+    margin-left: 0.25rem;
+  }
+
+  // Publications — stack image on top of metadata block
+  .panel .publications ol.bibliography > li {
+    flex-direction: column;
+    gap: 0;
+    padding: 0.85rem 0.85rem;
+  }
+  .panel .publications ol.bibliography > li > .col-sm-2 {
+    flex: 0 0 auto;
+    max-width: 100%;
+    display: flex;
+    align-items: center;
+    gap: 0.7rem;
+    margin-bottom: 0.55rem;
+  }
+  .panel .publications ol.bibliography > li figure.preview,
+  .panel .publications ol.bibliography > li .preview {
+    width: 88px;
+    max-width: 88px;
+    margin: 0;
+  }
+  .panel .publications ol.bibliography > li figure.preview picture,
+  .panel .publications ol.bibliography > li figure.preview img,
+  .panel .publications ol.bibliography > li img.preview {
+    width: 88px;
+    height: 64px;
+    max-height: 64px;
+  }
+  .panel .publications ol.bibliography > li .abbr {
+    margin: 0;
+  }
+
+  // Social row — give icons a touch-target sized hit area
+  .panel .social .contact-icons a {
+    width: 2.2rem;
+    height: 2.2rem;
+    font-size: 1.05rem;
+  }
+
+  // News table — let content take the full width and keep dates compact
+  .panel .news table.table tr th {
+    width: 38%;
+    font-size: 0.7rem;
+    padding-right: 0.5rem;
+  }
+  .panel .news table.table tr td {
+    font-size: 0.85rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .panel.hero-panel .hero-photo {
+    width: 84px;
+  }
+
+  // Smaller link buttons inside publications so 5 buttons don't blow up
+  .panel .publications ol.bibliography > li .links a.btn {
+    font-size: 0.66rem;
+    padding: 0.08rem 0.42rem !important;
   }
 }

--- a/_sass/_panels.scss
+++ b/_sass/_panels.scss
@@ -1,0 +1,491 @@
+/******************************************************************************
+ * Dashboard-style panels (inspired by structured-card visual reference)
+ *****************************************************************************/
+
+.panel {
+  background-color: var(--global-panel-bg);
+  border: 1px solid var(--global-panel-border-color);
+  border-radius: 12px;
+  margin-bottom: 1.25rem;
+  overflow: hidden;
+  box-shadow: 0 1px 0 rgba(15, 18, 23, 0.02);
+
+  > .panel-header {
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+    padding: 0.55rem 1rem;
+    background-color: var(--global-panel-header-bg);
+    border-bottom: 1px solid var(--global-panel-border-color);
+    font-weight: 600;
+    font-size: 0.95rem;
+    color: var(--global-text-color);
+    letter-spacing: 0.005em;
+
+    .panel-icon {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 1.6rem;
+      height: 1.6rem;
+      border-radius: 6px;
+      background-color: var(--global-bg-color);
+      border: 1px solid var(--global-panel-border-color);
+      color: var(--global-text-color-light);
+      font-size: 0.8rem;
+      flex-shrink: 0;
+    }
+
+    .panel-title {
+      flex-grow: 1;
+      color: var(--global-text-color);
+    }
+
+    .panel-meta {
+      color: var(--global-text-color-light);
+      font-size: 0.8rem;
+      font-weight: 400;
+    }
+  }
+
+  > .panel-body {
+    padding: 1rem 1.15rem 1.1rem 1.15rem;
+    color: var(--global-text-color);
+
+    > p:last-child,
+    > ul:last-child,
+    > ol:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  &.panel-flush > .panel-body {
+    padding: 0;
+  }
+}
+
+// Profile / hero panel
+.panel.hero-panel {
+  > .panel-body {
+    display: flex;
+    align-items: flex-start;
+    gap: 1.25rem;
+    flex-wrap: wrap;
+  }
+
+  .hero-text {
+    flex: 1 1 320px;
+    min-width: 0;
+
+    h1.post-title {
+      font-size: 1.85rem;
+      line-height: 1.2;
+      margin-bottom: 0.45rem;
+      font-weight: 600;
+      color: var(--global-text-color);
+
+      .font-weight-bold {
+        font-weight: 700;
+      }
+    }
+
+    p.desc {
+      color: var(--global-text-color-light);
+      font-size: 0.95rem;
+      line-height: 1.55;
+      margin-bottom: 0.4rem;
+
+      strong {
+        color: var(--global-text-color);
+      }
+    }
+  }
+
+  .hero-photo {
+    flex: 0 0 auto;
+    width: 165px;
+
+    img {
+      width: 100%;
+      height: auto;
+      border-radius: 10px;
+      border: 1px solid var(--global-panel-border-color);
+    }
+  }
+}
+
+// Grid for panels (memo-card grid)
+.memo-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 0.75rem;
+
+  .memo-card {
+    background-color: var(--global-bg-color);
+    border: 1px solid var(--global-panel-border-color);
+    border-radius: 8px;
+    padding: 0.75rem 0.85rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    font-size: 0.85rem;
+
+    .memo-head {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      font-size: 0.7rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      font-weight: 600;
+    }
+
+    .memo-tag {
+      padding: 0.1rem 0.5rem;
+      border-radius: 4px;
+      background: var(--memo-learning-bg);
+      color: var(--memo-learning-color);
+    }
+
+    .memo-date {
+      color: var(--global-text-color-muted);
+      font-weight: 600;
+    }
+
+    .memo-body {
+      color: var(--global-text-color);
+      line-height: 1.5;
+
+      strong {
+        color: var(--global-text-color);
+        font-weight: 600;
+      }
+    }
+
+    &.memo-decision .memo-tag {
+      background: var(--memo-decision-bg);
+      color: var(--memo-decision-color);
+    }
+    &.memo-planning .memo-tag {
+      background: var(--memo-planning-bg);
+      color: var(--memo-planning-color);
+    }
+  }
+}
+
+// Pill-style tags for category badges in lists
+.tag-pill {
+  display: inline-block;
+  padding: 0.1rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  background: var(--memo-learning-bg);
+  color: var(--memo-learning-color);
+  vertical-align: middle;
+  text-decoration: none;
+
+  &.tag-decision {
+    background: var(--memo-decision-bg);
+    color: var(--memo-decision-color);
+  }
+  &.tag-planning {
+    background: var(--memo-planning-bg);
+    color: var(--memo-planning-color);
+  }
+}
+
+// Generic dashboard meta row (small caption strip)
+.panel-caption {
+  padding: 0.5rem 1rem;
+  background-color: var(--global-panel-header-bg);
+  border-top: 1px solid var(--global-panel-border-color);
+  color: var(--global-text-color-light);
+  font-size: 0.78rem;
+  font-family: "JetBrains Mono", "SFMono-Regular", "Menlo", monospace;
+}
+
+// Adjust news/posts list inside a panel
+.panel .panel-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+
+  > li {
+    display: flex;
+    gap: 1rem;
+    align-items: flex-start;
+    padding: 0.65rem 1.15rem;
+    border-bottom: 1px solid var(--global-panel-border-color);
+    font-size: 0.92rem;
+    line-height: 1.5;
+
+    &:last-child {
+      border-bottom: 0;
+    }
+
+    .panel-list-date {
+      flex: 0 0 110px;
+      color: var(--global-text-color-muted);
+      font-family: "JetBrains Mono", "SFMono-Regular", "Menlo", monospace;
+      font-size: 0.8rem;
+      padding-top: 0.05rem;
+    }
+
+    .panel-list-content {
+      flex: 1 1 auto;
+      min-width: 0;
+      color: var(--global-text-color);
+
+      a {
+        color: var(--global-text-color);
+        text-decoration: none;
+        border-bottom: 1px dashed var(--global-panel-border-color);
+
+        &:hover {
+          color: var(--global-theme-color);
+          border-bottom-color: var(--global-theme-color);
+        }
+      }
+    }
+  }
+}
+
+// Publications list inside a panel
+.panel .publications {
+  margin-top: 0;
+
+  ol.bibliography {
+    > li {
+      padding: 0.85rem 1.15rem;
+      border-bottom: 1px solid var(--global-panel-border-color);
+      margin-bottom: 0;
+
+      &:last-child {
+        border-bottom: 0;
+      }
+
+      .title {
+        font-size: 1rem;
+        font-weight: 600;
+        color: var(--global-text-color);
+      }
+
+      .author,
+      .periodical {
+        font-size: 0.88rem;
+        color: var(--global-text-color-light);
+      }
+
+      .links {
+        margin-top: 0.4rem;
+
+        a.btn {
+          font-size: 0.75rem;
+          padding: 0.15rem 0.55rem !important;
+          border-radius: 4px !important;
+          margin-right: 0.25rem !important;
+          margin-bottom: 0.25rem;
+          background-color: var(--global-bg-color);
+          color: var(--global-text-color) !important;
+          border: 1px solid var(--global-panel-border-color) !important;
+          text-transform: none;
+          letter-spacing: 0;
+
+          &:hover {
+            color: var(--global-theme-color) !important;
+            border-color: var(--global-theme-color) !important;
+          }
+        }
+      }
+
+      .abbr {
+        margin-bottom: 0.4rem;
+
+        abbr {
+          background-color: var(--memo-learning-bg) !important;
+          color: var(--memo-learning-color) !important;
+          font-size: 0.7rem !important;
+          font-weight: 600 !important;
+          letter-spacing: 0.04em;
+          padding: 0.1rem 0.5rem !important;
+          border-radius: 4px !important;
+          text-transform: uppercase;
+
+          a {
+            color: var(--memo-learning-color) !important;
+          }
+        }
+      }
+    }
+  }
+}
+
+// Code block style ("Example action" panels in reference)
+.panel.code-panel > .panel-body {
+  padding: 0;
+
+  pre,
+  figure.highlight {
+    margin: 0;
+    border-radius: 0;
+    background-color: var(--global-code-bg-color) !important;
+    color: var(--global-text-color) !important;
+    border: 0;
+    padding: 0.95rem 1.15rem;
+    font-size: 0.85rem;
+    line-height: 1.5;
+    overflow-x: auto;
+  }
+}
+
+// Hero chinese name (smaller and lighter)
+.hero-cn {
+  display: inline-block;
+  font-weight: 400;
+  font-size: 1.25rem;
+  color: var(--global-text-color-light);
+  margin-left: 0.4rem;
+  vertical-align: middle;
+}
+
+// Social row in panel body
+.panel .social {
+  text-align: left;
+
+  .contact-icons {
+    font-size: 1.25rem;
+
+    a {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 2.1rem;
+      height: 2.1rem;
+      margin-right: 0.3rem;
+      margin-bottom: 0.3rem;
+      border: 1px solid var(--global-panel-border-color);
+      border-radius: 6px;
+      background-color: var(--global-bg-color);
+      transition: all 0.15s ease;
+
+      i::before {
+        color: var(--global-text-color);
+      }
+
+      &:hover {
+        border-color: var(--global-theme-color);
+        background-color: var(--global-panel-header-bg);
+
+        i::before {
+          color: var(--global-theme-color);
+        }
+      }
+    }
+  }
+
+  .contact-note {
+    margin-top: 0.5rem;
+    color: var(--global-text-color-light);
+    font-size: 0.8rem;
+  }
+}
+
+// News table inside panels — make it list-like with rows
+.panel .news {
+  table.table {
+    margin-bottom: 0;
+    background: transparent;
+
+    tr {
+      th,
+      td {
+        font-size: 0.92rem;
+        color: var(--global-text-color);
+        padding: 0.5rem 0.75rem 0.5rem 0;
+        border-color: var(--global-panel-border-color);
+      }
+
+      th {
+        font-family:
+          "JetBrains Mono",
+          "SFMono-Regular",
+          "Menlo",
+          monospace;
+        font-size: 0.78rem;
+        font-weight: 500;
+        color: var(--global-text-color-muted);
+        white-space: nowrap;
+      }
+
+      td a {
+        color: var(--global-text-color);
+        text-decoration: none;
+        border-bottom: 1px dashed var(--global-panel-border-color);
+
+        &:hover {
+          color: var(--global-theme-color);
+          border-bottom-color: var(--global-theme-color);
+        }
+      }
+    }
+  }
+}
+
+// About page research notes
+.panel .panel-body {
+  > p,
+  > ul,
+  > ol {
+    font-size: 0.95rem;
+    line-height: 1.65;
+  }
+
+  > p > strong:only-child,
+  > p:has(> strong:only-child) {
+    color: var(--global-text-color);
+    font-weight: 600;
+    margin-bottom: 0.4rem;
+    margin-top: 0.85rem;
+  }
+
+  ul,
+  ol {
+    padding-left: 1.25rem;
+
+    li {
+      margin-bottom: 0.25rem;
+    }
+  }
+}
+
+// Charts / inline visual elements (sparkline-like)
+.panel-spark {
+  display: flex;
+  align-items: stretch;
+  gap: 2px;
+  height: 60px;
+  padding: 0.85rem 1.15rem 1rem;
+
+  .bar {
+    flex: 1;
+    background: var(--global-warning-color);
+    opacity: 0.85;
+    border-radius: 1px;
+  }
+}
+
+// Responsive: hero panel stacks on small
+@media (max-width: 575px) {
+  .panel.hero-panel > .panel-body {
+    flex-direction: column-reverse;
+    align-items: stretch;
+  }
+
+  .panel.hero-panel .hero-photo {
+    width: 130px;
+    align-self: flex-start;
+  }
+}

--- a/_sass/_panels.scss
+++ b/_sass/_panels.scss
@@ -313,9 +313,8 @@ img.z-depth-1,
       img.preview {
         display: block;
         width: 100%;
-        height: 80px;
-        max-height: 80px;
-        object-fit: cover;
+        max-width: 110px;
+        height: auto;
         border-radius: 4px;
         border: 0;
         background: transparent;
@@ -469,25 +468,34 @@ img.z-depth-1,
     padding: 0.75rem 0.85rem;
   }
 
-  // Hero — stack with photo above the text, but keep photo a sensible size
+  // Hero — keep photo on the right (small) next to name/bio
   .panel.hero-panel > .panel-body {
-    flex-direction: column-reverse;
+    flex-direction: row;
     align-items: flex-start;
     gap: 0.85rem;
-    padding: 0.85rem 0.85rem;
+    padding: 0.85rem;
+    flex-wrap: nowrap;
+  }
+  .panel.hero-panel .hero-text {
+    flex: 1 1 auto;
+    min-width: 0;
+    order: 0;
   }
   .panel.hero-panel .hero-photo {
+    flex: 0 0 auto;
     width: 96px;
+    order: 1;
     align-self: flex-start;
   }
   .panel.hero-panel .hero-photo img {
     height: auto;
   }
   .panel.hero-panel .hero-text h1.post-title {
-    font-size: 1.4rem;
+    font-size: 1.35rem;
+    line-height: 1.2;
   }
   .hero-cn {
-    font-size: 1rem;
+    font-size: 0.95rem;
     margin-left: 0.25rem;
   }
 
@@ -507,16 +515,16 @@ img.z-depth-1,
   }
   .panel .publications ol.bibliography > li figure.preview,
   .panel .publications ol.bibliography > li .preview {
-    width: 88px;
-    max-width: 88px;
+    width: 80px;
+    max-width: 80px;
     margin: 0;
   }
   .panel .publications ol.bibliography > li figure.preview picture,
   .panel .publications ol.bibliography > li figure.preview img,
   .panel .publications ol.bibliography > li img.preview {
-    width: 88px;
-    height: 64px;
-    max-height: 64px;
+    width: 80px;
+    max-width: 80px;
+    height: auto;
   }
   .panel .publications ol.bibliography > li .abbr {
     margin: 0;
@@ -543,6 +551,9 @@ img.z-depth-1,
 @media (max-width: 480px) {
   .panel.hero-panel .hero-photo {
     width: 84px;
+  }
+  .panel.hero-panel .hero-text h1.post-title {
+    font-size: 1.2rem;
   }
 
   // Smaller link buttons inside publications so 5 buttons don't blow up

--- a/_sass/_panels.scss
+++ b/_sass/_panels.scss
@@ -317,13 +317,8 @@ img.z-depth-1,
         max-height: 80px;
         object-fit: cover;
         border-radius: 4px;
-        border: 1px solid var(--global-panel-border-color);
-        background: var(--global-panel-header-bg);
-      }
-
-      figure.preview picture img {
         border: 0;
-        border-radius: 0;
+        background: transparent;
       }
 
       &:last-child {

--- a/_sass/_panels.scss
+++ b/_sass/_panels.scss
@@ -29,7 +29,7 @@ img.z-depth-1,
 
 .panel {
   background-color: var(--global-panel-bg);
-  border: 1px solid var(--global-panel-border-color);
+  border: 2px solid var(--global-panel-border-color);
   border-radius: 8px;
   margin-bottom: 14px;
   overflow: hidden;
@@ -41,7 +41,7 @@ img.z-depth-1,
     gap: 0.5rem;
     padding: 0.4rem 0.75rem;
     background-color: var(--global-panel-header-bg);
-    border-bottom: 1px solid var(--global-panel-border-color);
+    border-bottom: 2px solid var(--global-panel-border-color);
     font-weight: 600;
     font-size: 0.88rem;
     color: var(--global-text-color);

--- a/_sass/_panels.scss
+++ b/_sass/_panels.scss
@@ -1,24 +1,29 @@
 /******************************************************************************
- * Dashboard-style panels (inspired by structured-card visual reference)
+ * Dashboard-style panels (faithful recreation of structured-card visual ref)
  *****************************************************************************/
+
+// Page background — slightly warm off-white with a subtle paper feel
+body {
+  background-color: var(--global-bg-color);
+}
 
 .panel {
   background-color: var(--global-panel-bg);
   border: 1px solid var(--global-panel-border-color);
-  border-radius: 12px;
-  margin-bottom: 1.25rem;
+  border-radius: 10px;
+  margin-bottom: 12px;
   overflow: hidden;
   box-shadow: 0 1px 0 rgba(15, 18, 23, 0.02);
 
   > .panel-header {
     display: flex;
     align-items: center;
-    gap: 0.55rem;
-    padding: 0.55rem 1rem;
+    gap: 0.5rem;
+    padding: 0.45rem 0.85rem;
     background-color: var(--global-panel-header-bg);
     border-bottom: 1px solid var(--global-panel-border-color);
     font-weight: 600;
-    font-size: 0.95rem;
+    font-size: 0.92rem;
     color: var(--global-text-color);
     letter-spacing: 0.005em;
 
@@ -26,30 +31,54 @@
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      width: 1.6rem;
-      height: 1.6rem;
-      border-radius: 6px;
-      background-color: var(--global-bg-color);
+      width: 1.35rem;
+      height: 1.35rem;
+      border-radius: 4px;
+      background-color: transparent;
       border: 1px solid var(--global-panel-border-color);
       color: var(--global-text-color-light);
-      font-size: 0.8rem;
+      font-size: 0.72rem;
       flex-shrink: 0;
     }
 
     .panel-title {
       flex-grow: 1;
       color: var(--global-text-color);
+      font-weight: 600;
     }
 
     .panel-meta {
       color: var(--global-text-color-light);
-      font-size: 0.8rem;
+      font-size: 0.78rem;
       font-weight: 400;
+      font-family: "JetBrains Mono", "SFMono-Regular", "Menlo", monospace;
+    }
+
+    .panel-legend {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.7rem;
+      font-size: 0.72rem;
+      font-weight: 500;
+      color: var(--global-text-color);
+      font-family:
+        "Inter",
+        -apple-system,
+        sans-serif;
+
+      .swatch {
+        display: inline-block;
+        width: 10px;
+        height: 10px;
+        border-radius: 2px;
+        margin-right: 0.3rem;
+        vertical-align: -1px;
+      }
     }
   }
 
   > .panel-body {
-    padding: 1rem 1.15rem 1.1rem 1.15rem;
+    padding: 0.85rem 1rem 0.95rem 1rem;
     color: var(--global-text-color);
 
     > p:last-child,
@@ -64,13 +93,14 @@
   }
 }
 
-// Profile / hero panel
+// =================== Hero / profile panel ===================
 .panel.hero-panel {
   > .panel-body {
     display: flex;
-    align-items: flex-start;
+    align-items: center;
     gap: 1.25rem;
     flex-wrap: wrap;
+    padding: 0.95rem 1rem;
   }
 
   .hero-text {
@@ -78,11 +108,12 @@
     min-width: 0;
 
     h1.post-title {
-      font-size: 1.85rem;
-      line-height: 1.2;
-      margin-bottom: 0.45rem;
-      font-weight: 600;
+      font-size: 1.75rem;
+      line-height: 1.15;
+      margin-bottom: 0.4rem;
+      font-weight: 700;
       color: var(--global-text-color);
+      letter-spacing: -0.01em;
 
       .font-weight-bold {
         font-weight: 700;
@@ -91,7 +122,7 @@
 
     p.desc {
       color: var(--global-text-color-light);
-      font-size: 0.95rem;
+      font-size: 0.93rem;
       line-height: 1.55;
       margin-bottom: 0.4rem;
 
@@ -103,58 +134,123 @@
 
   .hero-photo {
     flex: 0 0 auto;
-    width: 165px;
+    width: 130px;
 
     img {
       width: 100%;
       height: auto;
-      border-radius: 10px;
+      border-radius: 8px;
       border: 1px solid var(--global-panel-border-color);
     }
   }
 }
 
-// Grid for panels (memo-card grid)
-.memo-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-  gap: 0.75rem;
+// =================== Chart panels ===================
+.chart-panel {
+  > .panel-body {
+    padding: 0.55rem 0.85rem 0.7rem;
+    display: flex;
+    align-items: stretch;
+    gap: 0.5rem;
+  }
 
-  .memo-card {
-    background-color: var(--global-bg-color);
-    border: 1px solid var(--global-panel-border-color);
-    border-radius: 8px;
-    padding: 0.75rem 0.85rem;
+  .y-axis {
+    flex: 0 0 auto;
     display: flex;
     flex-direction: column;
-    gap: 0.35rem;
-    font-size: 0.85rem;
+    justify-content: space-between;
+    align-items: flex-end;
+    padding: 0.2rem 0.35rem 0.2rem 0;
+    font-family: "JetBrains Mono", "SFMono-Regular", monospace;
+    font-size: 0.62rem;
+    color: var(--global-text-color-muted);
+    line-height: 1;
+    min-width: 32px;
+    text-align: right;
+  }
+
+  .chart-svg-wrap {
+    flex: 1 1 auto;
+    min-width: 0;
+    position: relative;
+    padding: 0;
+    background-image:
+      repeating-linear-gradient(
+        to top,
+        transparent 0,
+        transparent 24%,
+        rgba(0, 0, 0, 0.04) 24%,
+        rgba(0, 0, 0, 0.04) calc(24% + 1px)
+      );
+  }
+
+  svg.chart {
+    width: 100%;
+    height: 80px;
+    display: block;
+  }
+
+  &.chart-tall svg.chart {
+    height: 110px;
+  }
+
+  &.chart-bars svg.chart {
+    height: 95px;
+  }
+}
+
+// =================== Memo cards ===================
+.memo-section > .panel-body {
+  padding: 0.9rem 1rem 1.1rem;
+}
+
+.memo-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.55rem;
+
+  .memo-card {
+    background-color: var(--global-panel-bg);
+    border: 1px solid var(--global-panel-border-color);
+    border-radius: 6px;
+    padding: 0.55rem 0.65rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+    font-size: 0.78rem;
+    line-height: 1.4;
 
     .memo-head {
       display: flex;
       align-items: center;
       justify-content: space-between;
-      font-size: 0.7rem;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-      font-weight: 600;
+      gap: 0.25rem;
     }
 
     .memo-tag {
-      padding: 0.1rem 0.5rem;
-      border-radius: 4px;
+      padding: 0.05rem 0.4rem;
+      border-radius: 3px;
+      font-size: 0.62rem;
+      font-weight: 700;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
       background: var(--memo-learning-bg);
       color: var(--memo-learning-color);
     }
 
-    .memo-date {
+    .memo-day {
+      font-family: "JetBrains Mono", "SFMono-Regular", monospace;
+      font-size: 0.62rem;
+      font-weight: 700;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
       color: var(--global-text-color-muted);
-      font-weight: 600;
     }
 
     .memo-body {
       color: var(--global-text-color);
-      line-height: 1.5;
+      font-size: 0.78rem;
+      line-height: 1.45;
 
       strong {
         color: var(--global-text-color);
@@ -173,14 +269,145 @@
   }
 }
 
-// Pill-style tags for category badges in lists
+// Timeline scrubber strip in middle of memo grid
+.timeline {
+  margin: 0.7rem 0 0.5rem;
+  height: 28px;
+  position: relative;
+
+  .timeline-track {
+    position: absolute;
+    top: 13px;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: var(--global-panel-border-color);
+  }
+
+  .timeline-mark {
+    position: absolute;
+    top: 8px;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: var(--global-panel-bg);
+    border: 2px solid var(--global-text-color-muted);
+    transform: translateX(-50%);
+
+    &.mark-learning {
+      border-color: var(--memo-learning-color);
+    }
+    &.mark-decision {
+      border-color: var(--memo-decision-color);
+    }
+    &.mark-planning {
+      border-color: var(--memo-planning-color);
+    }
+  }
+}
+
+// =================== Code-style example panels ===================
+.code-panel {
+  > .panel-body {
+    padding: 0;
+    background: var(--global-panel-bg);
+  }
+
+  pre,
+  figure.highlight,
+  .code-block {
+    margin: 0;
+    border-radius: 0;
+    background-color: var(--global-panel-bg) !important;
+    color: var(--global-text-color) !important;
+    border: 0;
+    padding: 0.7rem 0.95rem 0.85rem;
+    font-family: "JetBrains Mono", "SFMono-Regular", "Menlo", monospace;
+    font-size: 0.78rem;
+    line-height: 1.55;
+    overflow-x: auto;
+    white-space: pre;
+  }
+
+  .code-suppressed {
+    color: var(--global-text-color-muted);
+    background: var(--global-panel-header-bg);
+    display: block;
+    padding: 0.05rem 0.5rem;
+    margin: 0.3rem 0;
+    border-radius: 3px;
+    font-size: 0.72rem;
+    width: fit-content;
+    font-style: italic;
+  }
+
+  .code-comment {
+    color: var(--global-text-color-muted);
+  }
+
+  .code-keyword {
+    color: var(--global-theme-color);
+    font-weight: 500;
+  }
+  .code-string {
+    color: #b03127;
+  }
+  .code-fn {
+    color: #6b50a6;
+  }
+  .code-num {
+    color: #246d4d;
+  }
+
+  .code-output {
+    background: #1c2026;
+    color: #d3eedd;
+    margin: 0.5rem 0.7rem 0.7rem;
+    padding: 0.55rem 0.7rem;
+    border-radius: 5px;
+    font-family: "JetBrains Mono", "SFMono-Regular", monospace;
+    font-size: 0.74rem;
+    line-height: 1.5;
+    white-space: pre-wrap;
+    word-break: break-word;
+
+    .out-title {
+      color: #f0c08b;
+      display: block;
+      margin-bottom: 0.2rem;
+    }
+  }
+}
+
+.example-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+
+  @media (max-width: 767px) {
+    grid-template-columns: 1fr;
+  }
+}
+
+// Pair of side-by-side panels generic
+.panel-row-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 12px;
+
+  @media (max-width: 991px) {
+    grid-template-columns: 1fr;
+  }
+}
+
+// =================== Pill tag (general) ===================
 .tag-pill {
   display: inline-block;
-  padding: 0.1rem 0.5rem;
-  border-radius: 4px;
-  font-size: 0.7rem;
-  font-weight: 600;
-  letter-spacing: 0.04em;
+  padding: 0.05rem 0.45rem;
+  border-radius: 3px;
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
   background: var(--memo-learning-bg);
   color: var(--memo-learning-color);
@@ -197,207 +424,34 @@
   }
 }
 
-// Generic dashboard meta row (small caption strip)
-.panel-caption {
-  padding: 0.5rem 1rem;
-  background-color: var(--global-panel-header-bg);
-  border-top: 1px solid var(--global-panel-border-color);
-  color: var(--global-text-color-light);
-  font-size: 0.78rem;
-  font-family: "JetBrains Mono", "SFMono-Regular", "Menlo", monospace;
-}
-
-// Adjust news/posts list inside a panel
-.panel .panel-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-
-  > li {
-    display: flex;
-    gap: 1rem;
-    align-items: flex-start;
-    padding: 0.65rem 1.15rem;
-    border-bottom: 1px solid var(--global-panel-border-color);
-    font-size: 0.92rem;
-    line-height: 1.5;
-
-    &:last-child {
-      border-bottom: 0;
-    }
-
-    .panel-list-date {
-      flex: 0 0 110px;
-      color: var(--global-text-color-muted);
-      font-family: "JetBrains Mono", "SFMono-Regular", "Menlo", monospace;
-      font-size: 0.8rem;
-      padding-top: 0.05rem;
-    }
-
-    .panel-list-content {
-      flex: 1 1 auto;
-      min-width: 0;
-      color: var(--global-text-color);
-
-      a {
-        color: var(--global-text-color);
-        text-decoration: none;
-        border-bottom: 1px dashed var(--global-panel-border-color);
-
-        &:hover {
-          color: var(--global-theme-color);
-          border-bottom-color: var(--global-theme-color);
-        }
-      }
-    }
-  }
-}
-
-// Publications list inside a panel
-.panel .publications {
-  margin-top: 0;
-
-  > h1,
-  > h2.bibliography {
-    display: none;
-  }
-
-  ol.bibliography {
-    > li {
-      padding: 0.85rem 1.15rem;
-      border-bottom: 1px solid var(--global-panel-border-color);
-      margin-bottom: 0;
-      display: flex;
-      gap: 0.85rem;
-      align-items: flex-start;
-
-      > .col-sm-2 {
-        flex: 0 0 80px;
-        max-width: 80px;
-        padding: 0;
-      }
-
-      > .col-sm-8,
-      > .col-sm-10 {
-        flex: 1 1 auto;
-        max-width: none;
-        padding: 0;
-      }
-
-      img.preview {
-        width: 100%;
-        height: 56px;
-        object-fit: cover;
-        border-radius: 6px;
-        border: 1px solid var(--global-panel-border-color);
-      }
-
-      &:last-child {
-        border-bottom: 0;
-      }
-
-      .title {
-        font-size: 1rem;
-        font-weight: 600;
-        color: var(--global-text-color);
-      }
-
-      .author,
-      .periodical {
-        font-size: 0.88rem;
-        color: var(--global-text-color-light);
-      }
-
-      .links {
-        margin-top: 0.4rem;
-
-        a.btn {
-          font-size: 0.75rem;
-          padding: 0.15rem 0.55rem !important;
-          border-radius: 4px !important;
-          margin-right: 0.25rem !important;
-          margin-bottom: 0.25rem;
-          background-color: var(--global-bg-color);
-          color: var(--global-text-color) !important;
-          border: 1px solid var(--global-panel-border-color) !important;
-          text-transform: none;
-          letter-spacing: 0;
-
-          &:hover {
-            color: var(--global-theme-color) !important;
-            border-color: var(--global-theme-color) !important;
-          }
-        }
-      }
-
-      .abbr {
-        margin-bottom: 0.4rem;
-
-        abbr {
-          background-color: var(--memo-learning-bg) !important;
-          color: var(--memo-learning-color) !important;
-          font-size: 0.7rem !important;
-          font-weight: 600 !important;
-          letter-spacing: 0.04em;
-          padding: 0.1rem 0.5rem !important;
-          border-radius: 4px !important;
-          text-transform: uppercase;
-
-          a {
-            color: var(--memo-learning-color) !important;
-          }
-        }
-      }
-    }
-  }
-}
-
-// Code block style ("Example action" panels in reference)
-.panel.code-panel > .panel-body {
-  padding: 0;
-
-  pre,
-  figure.highlight {
-    margin: 0;
-    border-radius: 0;
-    background-color: var(--global-code-bg-color) !important;
-    color: var(--global-text-color) !important;
-    border: 0;
-    padding: 0.95rem 1.15rem;
-    font-size: 0.85rem;
-    line-height: 1.5;
-    overflow-x: auto;
-  }
-}
-
-// Hero chinese name (smaller and lighter)
+// =================== Hero chinese name ===================
 .hero-cn {
   display: inline-block;
   font-weight: 400;
-  font-size: 1.25rem;
+  font-size: 1.15rem;
   color: var(--global-text-color-light);
-  margin-left: 0.4rem;
+  margin-left: 0.35rem;
   vertical-align: middle;
 }
 
-// Social row in panel body
+// =================== Social row ===================
 .panel .social {
   text-align: left;
 
   .contact-icons {
-    font-size: 1.25rem;
+    font-size: 1.1rem;
 
     a {
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      width: 2.1rem;
-      height: 2.1rem;
-      margin-right: 0.3rem;
-      margin-bottom: 0.3rem;
+      width: 1.9rem;
+      height: 1.9rem;
+      margin-right: 0.25rem;
+      margin-bottom: 0.25rem;
       border: 1px solid var(--global-panel-border-color);
-      border-radius: 6px;
-      background-color: var(--global-bg-color);
+      border-radius: 5px;
+      background-color: var(--global-panel-bg);
       transition: all 0.15s ease;
 
       i::before {
@@ -418,11 +472,11 @@
   .contact-note {
     margin-top: 0.5rem;
     color: var(--global-text-color-light);
-    font-size: 0.8rem;
+    font-size: 0.78rem;
   }
 }
 
-// News table inside panels — make it list-like with rows
+// =================== News table inside panel ===================
 .panel .news {
   table.table {
     margin-bottom: 0;
@@ -431,10 +485,11 @@
     tr {
       th,
       td {
-        font-size: 0.92rem;
+        font-size: 0.88rem;
         color: var(--global-text-color);
-        padding: 0.5rem 0.75rem 0.5rem 0;
+        padding: 0.42rem 0.6rem 0.42rem 0;
         border-color: var(--global-panel-border-color);
+        line-height: 1.45;
       }
 
       th {
@@ -443,7 +498,7 @@
           "SFMono-Regular",
           "Menlo",
           monospace;
-        font-size: 0.78rem;
+        font-size: 0.72rem;
         font-weight: 500;
         color: var(--global-text-color-muted);
         white-space: nowrap;
@@ -463,41 +518,137 @@
   }
 }
 
-// About page research notes
+// =================== About research notes content ===================
 .panel .panel-body {
   > p,
   > ul,
   > ol {
-    font-size: 0.95rem;
-    line-height: 1.65;
-  }
-
-  > p > strong:only-child,
-  > p:has(> strong:only-child) {
-    color: var(--global-text-color);
-    font-weight: 600;
-    margin-bottom: 0.4rem;
-    margin-top: 0.85rem;
+    font-size: 0.92rem;
+    line-height: 1.6;
   }
 
   ul,
   ol {
-    padding-left: 1.25rem;
+    padding-left: 1.15rem;
 
     li {
-      margin-bottom: 0.25rem;
+      margin-bottom: 0.2rem;
     }
   }
 }
 
-// Blog post-list inside a panel
+// =================== Publications inside panel ===================
+.panel .publications {
+  margin-top: 0;
+
+  > h1,
+  > h2.bibliography {
+    display: none;
+  }
+
+  ol.bibliography {
+    > li {
+      padding: 0.7rem 1rem;
+      border-bottom: 1px solid var(--global-panel-border-color);
+      margin-bottom: 0;
+      display: flex;
+      gap: 0.85rem;
+      align-items: flex-start;
+
+      > .col-sm-2 {
+        flex: 0 0 72px;
+        max-width: 72px;
+        padding: 0;
+      }
+
+      > .col-sm-8,
+      > .col-sm-10 {
+        flex: 1 1 auto;
+        max-width: none;
+        padding: 0;
+        font-size: 0.88rem;
+      }
+
+      img.preview {
+        width: 100%;
+        height: 50px;
+        object-fit: cover;
+        border-radius: 4px;
+        border: 1px solid var(--global-panel-border-color);
+      }
+
+      &:last-child {
+        border-bottom: 0;
+      }
+
+      .title {
+        font-size: 0.95rem;
+        font-weight: 600;
+        color: var(--global-text-color);
+        line-height: 1.35;
+      }
+
+      .author,
+      .periodical {
+        font-size: 0.82rem;
+        color: var(--global-text-color-light);
+      }
+
+      .links {
+        margin-top: 0.35rem;
+
+        a.btn {
+          font-size: 0.7rem;
+          padding: 0.1rem 0.5rem !important;
+          border-radius: 3px !important;
+          margin-right: 0.2rem !important;
+          margin-bottom: 0.2rem;
+          background-color: var(--global-bg-color);
+          color: var(--global-text-color) !important;
+          border: 1px solid var(--global-panel-border-color) !important;
+          text-transform: none;
+          letter-spacing: 0;
+          font-weight: 500;
+          line-height: 1.4;
+
+          &:hover {
+            color: var(--global-theme-color) !important;
+            border-color: var(--global-theme-color) !important;
+          }
+        }
+      }
+
+      .abbr {
+        margin-top: 0.3rem;
+        margin-bottom: 0.2rem;
+
+        abbr {
+          background-color: var(--memo-learning-bg) !important;
+          color: var(--memo-learning-color) !important;
+          font-size: 0.62rem !important;
+          font-weight: 700 !important;
+          letter-spacing: 0.06em;
+          padding: 0.05rem 0.45rem !important;
+          border-radius: 3px !important;
+          text-transform: uppercase;
+
+          a {
+            color: var(--memo-learning-color) !important;
+          }
+        }
+      }
+    }
+  }
+}
+
+// =================== Blog post-list inside panel ===================
 .panel .post-list {
   margin-bottom: 0;
 
   > li {
     border-bottom: 1px solid var(--global-panel-border-color);
-    padding-top: 0.85rem;
-    padding-bottom: 0.85rem;
+    padding-top: 0.7rem;
+    padding-bottom: 0.7rem;
 
     &:last-child {
       border-bottom: 0;
@@ -509,20 +660,20 @@
     }
 
     h3 {
-      font-size: 1.05rem;
+      font-size: 1rem;
       font-weight: 600;
       margin-bottom: 0.25rem;
     }
 
     p {
-      font-size: 0.9rem;
+      font-size: 0.86rem;
       color: var(--global-text-color-light);
-      margin-bottom: 0.35rem;
+      margin-bottom: 0.3rem;
     }
 
     .post-meta,
     .post-tags {
-      font-size: 0.8rem;
+      font-size: 0.74rem;
       color: var(--global-text-color-muted);
     }
   }
@@ -531,46 +682,38 @@
 .panel .header-bar {
   border-bottom: 0;
   padding-top: 0;
-  padding-bottom: 0.75rem;
+  padding-bottom: 0.65rem;
   text-align: left;
 
   h1 {
-    font-size: 1.15rem;
+    font-size: 1.05rem;
     color: var(--global-text-color);
     font-weight: 600;
   }
   h2 {
-    font-size: 0.92rem;
+    font-size: 0.88rem;
     color: var(--global-text-color-light);
     margin: 0;
   }
 }
 
-// Charts / inline visual elements (sparkline-like)
-.panel-spark {
-  display: flex;
-  align-items: stretch;
-  gap: 2px;
-  height: 60px;
-  padding: 0.85rem 1.15rem 1rem;
-
-  .bar {
-    flex: 1;
-    background: var(--global-warning-color);
-    opacity: 0.85;
-    border-radius: 1px;
+// =================== Responsive ===================
+@media (max-width: 767px) {
+  .memo-grid {
+    grid-template-columns: repeat(2, 1fr);
   }
 }
 
-// Responsive: hero panel stacks on small
 @media (max-width: 575px) {
   .panel.hero-panel > .panel-body {
     flex-direction: column-reverse;
     align-items: stretch;
   }
-
   .panel.hero-panel .hero-photo {
-    width: 130px;
+    width: 110px;
     align-self: flex-start;
+  }
+  .memo-grid {
+    grid-template-columns: 1fr;
   }
 }

--- a/_sass/_panels.scss
+++ b/_sass/_panels.scss
@@ -1,8 +1,8 @@
 /******************************************************************************
- * Dashboard-style panels (faithful recreation of structured-card visual ref)
+ * Dashboard-style visual chrome (border, shape, color, font)
+ * Structure stays the same as the original al-folio about/page/post layouts.
  *****************************************************************************/
 
-// Page background — slightly warm off-white with a subtle paper feel
 body {
   background-color: var(--global-bg-color);
 }
@@ -53,28 +53,6 @@ body {
       font-weight: 400;
       font-family: "JetBrains Mono", "SFMono-Regular", "Menlo", monospace;
     }
-
-    .panel-legend {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.7rem;
-      font-size: 0.72rem;
-      font-weight: 500;
-      color: var(--global-text-color);
-      font-family:
-        "Inter",
-        -apple-system,
-        sans-serif;
-
-      .swatch {
-        display: inline-block;
-        width: 10px;
-        height: 10px;
-        border-radius: 2px;
-        margin-right: 0.3rem;
-        vertical-align: -1px;
-      }
-    }
   }
 
   > .panel-body {
@@ -85,6 +63,22 @@ body {
     > ul:last-child,
     > ol:last-child {
       margin-bottom: 0;
+    }
+
+    > p,
+    > ul,
+    > ol {
+      font-size: 0.92rem;
+      line-height: 1.6;
+    }
+
+    ul,
+    ol {
+      padding-left: 1.15rem;
+
+      li {
+        margin-bottom: 0.2rem;
+      }
     }
   }
 
@@ -145,262 +139,16 @@ body {
   }
 }
 
-// =================== Chart panels ===================
-.chart-panel {
-  > .panel-body {
-    padding: 0.55rem 0.85rem 0.7rem;
-    display: flex;
-    align-items: stretch;
-    gap: 0.5rem;
-  }
-
-  .y-axis {
-    flex: 0 0 auto;
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-    align-items: flex-end;
-    padding: 0.2rem 0.35rem 0.2rem 0;
-    font-family: "JetBrains Mono", "SFMono-Regular", monospace;
-    font-size: 0.62rem;
-    color: var(--global-text-color-muted);
-    line-height: 1;
-    min-width: 32px;
-    text-align: right;
-  }
-
-  .chart-svg-wrap {
-    flex: 1 1 auto;
-    min-width: 0;
-    position: relative;
-    padding: 0;
-    background-image:
-      repeating-linear-gradient(
-        to top,
-        transparent 0,
-        transparent 24%,
-        rgba(0, 0, 0, 0.04) 24%,
-        rgba(0, 0, 0, 0.04) calc(24% + 1px)
-      );
-  }
-
-  svg.chart {
-    width: 100%;
-    height: 80px;
-    display: block;
-  }
-
-  &.chart-tall svg.chart {
-    height: 110px;
-  }
-
-  &.chart-bars svg.chart {
-    height: 95px;
-  }
+.hero-cn {
+  display: inline-block;
+  font-weight: 400;
+  font-size: 1.15rem;
+  color: var(--global-text-color-light);
+  margin-left: 0.35rem;
+  vertical-align: middle;
 }
 
-// =================== Memo cards ===================
-.memo-section > .panel-body {
-  padding: 0.9rem 1rem 1.1rem;
-}
-
-.memo-grid {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 0.55rem;
-
-  .memo-card {
-    background-color: var(--global-panel-bg);
-    border: 1px solid var(--global-panel-border-color);
-    border-radius: 6px;
-    padding: 0.55rem 0.65rem;
-    display: flex;
-    flex-direction: column;
-    gap: 0.3rem;
-    font-size: 0.78rem;
-    line-height: 1.4;
-
-    .memo-head {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 0.25rem;
-    }
-
-    .memo-tag {
-      padding: 0.05rem 0.4rem;
-      border-radius: 3px;
-      font-size: 0.62rem;
-      font-weight: 700;
-      letter-spacing: 0.06em;
-      text-transform: uppercase;
-      background: var(--memo-learning-bg);
-      color: var(--memo-learning-color);
-    }
-
-    .memo-day {
-      font-family: "JetBrains Mono", "SFMono-Regular", monospace;
-      font-size: 0.62rem;
-      font-weight: 700;
-      letter-spacing: 0.06em;
-      text-transform: uppercase;
-      color: var(--global-text-color-muted);
-    }
-
-    .memo-body {
-      color: var(--global-text-color);
-      font-size: 0.78rem;
-      line-height: 1.45;
-
-      strong {
-        color: var(--global-text-color);
-        font-weight: 600;
-      }
-    }
-
-    &.memo-decision .memo-tag {
-      background: var(--memo-decision-bg);
-      color: var(--memo-decision-color);
-    }
-    &.memo-planning .memo-tag {
-      background: var(--memo-planning-bg);
-      color: var(--memo-planning-color);
-    }
-  }
-}
-
-// Timeline scrubber strip in middle of memo grid
-.timeline {
-  margin: 0.7rem 0 0.5rem;
-  height: 28px;
-  position: relative;
-
-  .timeline-track {
-    position: absolute;
-    top: 13px;
-    left: 0;
-    right: 0;
-    height: 2px;
-    background: var(--global-panel-border-color);
-  }
-
-  .timeline-mark {
-    position: absolute;
-    top: 8px;
-    width: 12px;
-    height: 12px;
-    border-radius: 50%;
-    background: var(--global-panel-bg);
-    border: 2px solid var(--global-text-color-muted);
-    transform: translateX(-50%);
-
-    &.mark-learning {
-      border-color: var(--memo-learning-color);
-    }
-    &.mark-decision {
-      border-color: var(--memo-decision-color);
-    }
-    &.mark-planning {
-      border-color: var(--memo-planning-color);
-    }
-  }
-}
-
-// =================== Code-style example panels ===================
-.code-panel {
-  > .panel-body {
-    padding: 0;
-    background: var(--global-panel-bg);
-  }
-
-  pre,
-  figure.highlight,
-  .code-block {
-    margin: 0;
-    border-radius: 0;
-    background-color: var(--global-panel-bg) !important;
-    color: var(--global-text-color) !important;
-    border: 0;
-    padding: 0.7rem 0.95rem 0.85rem;
-    font-family: "JetBrains Mono", "SFMono-Regular", "Menlo", monospace;
-    font-size: 0.78rem;
-    line-height: 1.55;
-    overflow-x: auto;
-    white-space: pre;
-  }
-
-  .code-suppressed {
-    color: var(--global-text-color-muted);
-    background: var(--global-panel-header-bg);
-    display: block;
-    padding: 0.05rem 0.5rem;
-    margin: 0.3rem 0;
-    border-radius: 3px;
-    font-size: 0.72rem;
-    width: fit-content;
-    font-style: italic;
-  }
-
-  .code-comment {
-    color: var(--global-text-color-muted);
-  }
-
-  .code-keyword {
-    color: var(--global-theme-color);
-    font-weight: 500;
-  }
-  .code-string {
-    color: #b03127;
-  }
-  .code-fn {
-    color: #6b50a6;
-  }
-  .code-num {
-    color: #246d4d;
-  }
-
-  .code-output {
-    background: #1c2026;
-    color: #d3eedd;
-    margin: 0.5rem 0.7rem 0.7rem;
-    padding: 0.55rem 0.7rem;
-    border-radius: 5px;
-    font-family: "JetBrains Mono", "SFMono-Regular", monospace;
-    font-size: 0.74rem;
-    line-height: 1.5;
-    white-space: pre-wrap;
-    word-break: break-word;
-
-    .out-title {
-      color: #f0c08b;
-      display: block;
-      margin-bottom: 0.2rem;
-    }
-  }
-}
-
-.example-row {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 12px;
-
-  @media (max-width: 767px) {
-    grid-template-columns: 1fr;
-  }
-}
-
-// Pair of side-by-side panels generic
-.panel-row-2 {
-  display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
-  gap: 12px;
-
-  @media (max-width: 991px) {
-    grid-template-columns: 1fr;
-  }
-}
-
-// =================== Pill tag (general) ===================
+// =================== Pill tag (used for venue badges) ===================
 .tag-pill {
   display: inline-block;
   padding: 0.05rem 0.45rem;
@@ -424,17 +172,7 @@ body {
   }
 }
 
-// =================== Hero chinese name ===================
-.hero-cn {
-  display: inline-block;
-  font-weight: 400;
-  font-size: 1.15rem;
-  color: var(--global-text-color-light);
-  margin-left: 0.35rem;
-  vertical-align: middle;
-}
-
-// =================== Social row ===================
+// =================== Social row inside panel ===================
 .panel .social {
   text-align: left;
 
@@ -493,11 +231,7 @@ body {
       }
 
       th {
-        font-family:
-          "JetBrains Mono",
-          "SFMono-Regular",
-          "Menlo",
-          monospace;
+        font-family: "JetBrains Mono", "SFMono-Regular", "Menlo", monospace;
         font-size: 0.72rem;
         font-weight: 500;
         color: var(--global-text-color-muted);
@@ -514,25 +248,6 @@ body {
           border-bottom-color: var(--global-theme-color);
         }
       }
-    }
-  }
-}
-
-// =================== About research notes content ===================
-.panel .panel-body {
-  > p,
-  > ul,
-  > ol {
-    font-size: 0.92rem;
-    line-height: 1.6;
-  }
-
-  ul,
-  ol {
-    padding-left: 1.15rem;
-
-    li {
-      margin-bottom: 0.2rem;
     }
   }
 }
@@ -697,13 +412,20 @@ body {
   }
 }
 
-// =================== Responsive ===================
-@media (max-width: 767px) {
-  .memo-grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
+// =================== Inline code inside panels (post bodies) ===================
+.panel pre,
+.panel figure.highlight {
+  background-color: var(--global-code-bg-color);
+  border: 1px solid var(--global-panel-border-color);
+  border-radius: 6px;
+  padding: 0.7rem 0.95rem;
+  font-family: "JetBrains Mono", "SFMono-Regular", "Menlo", monospace;
+  font-size: 0.82rem;
+  line-height: 1.55;
+  color: var(--global-text-color);
 }
 
+// =================== Responsive ===================
 @media (max-width: 575px) {
   .panel.hero-panel > .panel-body {
     flex-direction: column-reverse;
@@ -712,8 +434,5 @@ body {
   .panel.hero-panel .hero-photo {
     width: 110px;
     align-self: flex-start;
-  }
-  .memo-grid {
-    grid-template-columns: 1fr;
   }
 }

--- a/_sass/_panels.scss
+++ b/_sass/_panels.scss
@@ -7,37 +7,54 @@ body {
   background-color: var(--global-bg-color);
 }
 
+// Kill Bootstrap/MDB drop shadows globally — reference is shadow-free
+.z-depth-0,
+.z-depth-1,
+.z-depth-2,
+.z-depth-3,
+.z-depth-4,
+.z-depth-5,
+.card,
+.card.hoverable,
+.btn,
+.btn-sm,
+.shadow,
+.shadow-sm,
+.shadow-lg,
+img.z-depth-1,
+.rounded.z-depth-1 {
+  box-shadow: none !important;
+  -webkit-box-shadow: none !important;
+}
+
 .panel {
   background-color: var(--global-panel-bg);
   border: 1px solid var(--global-panel-border-color);
-  border-radius: 10px;
-  margin-bottom: 12px;
+  border-radius: 8px;
+  margin-bottom: 14px;
   overflow: hidden;
-  box-shadow: 0 1px 0 rgba(15, 18, 23, 0.02);
+  box-shadow: none;
 
   > .panel-header {
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    padding: 0.45rem 0.85rem;
+    padding: 0.4rem 0.75rem;
     background-color: var(--global-panel-header-bg);
     border-bottom: 1px solid var(--global-panel-border-color);
     font-weight: 600;
-    font-size: 0.92rem;
+    font-size: 0.88rem;
     color: var(--global-text-color);
-    letter-spacing: 0.005em;
+    letter-spacing: 0;
 
     .panel-icon {
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      width: 1.35rem;
-      height: 1.35rem;
-      border-radius: 4px;
-      background-color: transparent;
-      border: 1px solid var(--global-panel-border-color);
+      width: 1.1rem;
+      height: 1.1rem;
       color: var(--global-text-color-light);
-      font-size: 0.72rem;
+      font-size: 0.92rem;
       flex-shrink: 0;
     }
 

--- a/_sass/_themes.scss
+++ b/_sass/_themes.scss
@@ -5,23 +5,36 @@
 @use "sass:color";
 
 :root {
-  --global-bg-color: #{$white-color};
-  --global-code-bg-color: #{$code-bg-color-light};
-  --global-text-color: #{$black-color};
-  --global-text-color-light: #{$grey-color};
-  --global-theme-color: #{$purple-color};
-  --global-hover-color: #{$purple-color};
+  --global-bg-color: #{$grey-page-bg};
+  --global-panel-bg: #{$panel-bg};
+  --global-panel-header-bg: #{$panel-header-bg};
+  --global-panel-border-color: #{$grey-color-border};
+  --global-code-bg-color: #f4f6f8;
+  --global-text-color: #1f2933;
+  --global-text-color-light: #6b7177;
+  --global-text-color-muted: #8a9099;
+  --global-theme-color: #{$blue-color};
+  --global-accent-color: #{$green-color};
+  --global-warning-color: #{$orange-color};
+  --global-hover-color: #{$blue-color-dark};
   --global-hover-text-color: #{$white-color};
   --global-footer-bg-color: #{$grey-color-dark};
   --global-footer-text-color: #{$grey-color-light};
   --global-footer-link-color: #{$white-color};
   --global-distill-app-color: #{$grey-color};
-  --global-divider-color: rgba(0, 0, 0, 0.1);
-  --global-card-bg-color: #{$white-color};
+  --global-divider-color: #{$grey-color-border};
+  --global-card-bg-color: #{$panel-bg};
   --global-highlight-color: #{$red-color-dark};
   --global-back-to-top-text-color: #{$white-color};
   --global-newsletter-bg-color: #{$white-color};
   --global-newsletter-text-color: #{$black-color};
+
+  --memo-learning-bg: #{$blue-color-soft};
+  --memo-learning-color: #{$blue-color-dark};
+  --memo-decision-bg: #{$green-color-soft};
+  --memo-decision-color: #{$green-color-dark};
+  --memo-planning-bg: #{$orange-color-soft};
+  --memo-planning-color: #9c5b22;
 
   --global-tip-block: #42b983;
   --global-tip-block-bg: #e2f5ec;
@@ -69,22 +82,35 @@
 }
 
 html[data-theme="dark"] {
-  --global-bg-color: #{$grey-color-dark};
-  --global-code-bg-color: #{$code-bg-color-dark};
-  --global-text-color: #{$grey-color-light};
-  --global-text-color-light: #{$grey-color};
-  --global-theme-color: #{$cyan-color};
-  --global-hover-color: #{$cyan-color};
+  --global-bg-color: #15181c;
+  --global-panel-bg: #1c2026;
+  --global-panel-header-bg: #20242b;
+  --global-panel-border-color: #2c313a;
+  --global-code-bg-color: #20242b;
+  --global-text-color: #d9dde3;
+  --global-text-color-light: #9ba1aa;
+  --global-text-color-muted: #6b7177;
+  --global-theme-color: #6ea7e0;
+  --global-accent-color: #46b97f;
+  --global-warning-color: #e6a162;
+  --global-hover-color: #9bc2ec;
   --global-hover-text-color: #{$white-color};
   --global-footer-bg-color: #{$grey-color-light};
   --global-footer-text-color: #{$grey-color-dark};
   --global-footer-link-color: #{$black-color};
   --global-distill-app-color: #{$grey-color-light};
-  --global-divider-color: #424246;
-  --global-card-bg-color: #{$grey-900};
+  --global-divider-color: #2c313a;
+  --global-card-bg-color: #1c2026;
   --global-back-to-top-text-color: #{$black-color};
   --global-newsletter-bg-color: #{$grey-color-light};
   --global-newsletter-text-color: #{$grey-color-dark};
+
+  --memo-learning-bg: #1d3050;
+  --memo-learning-color: #b9d3f3;
+  --memo-decision-bg: #1d3a2a;
+  --memo-decision-color: #b3e0c2;
+  --memo-planning-bg: #3a2c1a;
+  --memo-planning-color: #ecc8a3;
 
   --global-tip-block: #42b983;
   --global-tip-block-bg: #e2f5ec;

--- a/_sass/_themes.scss
+++ b/_sass/_themes.scss
@@ -9,6 +9,7 @@
   --global-panel-bg: #{$panel-bg};
   --global-panel-header-bg: #{$panel-header-bg};
   --global-panel-border-color: #{$grey-color-border};
+  --global-panel-inner-border-color: #d6d3cc;
   --global-code-bg-color: #f4f1ea;
   --global-text-color: #2b2a26;
   --global-text-color-light: #6b6963;

--- a/_sass/_themes.scss
+++ b/_sass/_themes.scss
@@ -9,10 +9,10 @@
   --global-panel-bg: #{$panel-bg};
   --global-panel-header-bg: #{$panel-header-bg};
   --global-panel-border-color: #{$grey-color-border};
-  --global-code-bg-color: #f4f6f8;
-  --global-text-color: #1f2933;
-  --global-text-color-light: #6b7177;
-  --global-text-color-muted: #8a9099;
+  --global-code-bg-color: #f4f1ea;
+  --global-text-color: #2b2a26;
+  --global-text-color-light: #6b6963;
+  --global-text-color-muted: #8c8a83;
   --global-theme-color: #{$blue-color};
   --global-accent-color: #{$green-color};
   --global-warning-color: #{$orange-color};
@@ -29,12 +29,12 @@
   --global-newsletter-bg-color: #{$white-color};
   --global-newsletter-text-color: #{$black-color};
 
-  --memo-learning-bg: #{$blue-color-soft};
-  --memo-learning-color: #{$blue-color-dark};
-  --memo-decision-bg: #{$green-color-soft};
-  --memo-decision-color: #{$green-color-dark};
-  --memo-planning-bg: #{$orange-color-soft};
-  --memo-planning-color: #9c5b22;
+  --memo-learning-bg: #c7d8ec;
+  --memo-learning-color: #1f4f86;
+  --memo-decision-bg: #cae0d2;
+  --memo-decision-color: #246d4d;
+  --memo-planning-bg: #ecd0a8;
+  --memo-planning-color: #8a4a16;
 
   --global-tip-block: #42b983;
   --global-tip-block-bg: #e2f5ec;

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -5,29 +5,36 @@
 
 @use "sass:color";
 
-// Colors
-$red-color: #ff3636 !default;
-$red-color-dark: #b71c1c !default;
-$orange-color: #f29105 !default;
-$blue-color: #0076df !default;
-$blue-color-dark: #00369f !default;
+// Colors — dashboard-inspired palette
+$red-color: #e1483a !default;
+$red-color-dark: #b03127 !default;
+$orange-color: #d97a2c !default;
+$orange-color-soft: #f4ddc2 !default;
+$blue-color: #2b6fb5 !default;
+$blue-color-dark: #1f4f86 !default;
+$blue-color-soft: #d6e4f4 !default;
 $cyan-color: #2698ba !default;
 $light-cyan-color: color.adjust($cyan-color, $lightness: 25%);
-$green-color: #00ab37 !default;
-$green-color-lime: #b7d12a !default;
-$green-color-dark: #009f06 !default;
-$green-color-light: #ddffdd !default;
-$green-color-bright: #11d68b !default;
-$purple-color: #b509ac !default;
+$green-color: #2f9e6b !default;
+$green-color-lime: #9bbf3a !default;
+$green-color-dark: #246d4d !default;
+$green-color-soft: #d5ead9 !default;
+$green-color-bright: #46b97f !default;
+$purple-color: #6b50a6 !default;
 $light-purple-color: color.adjust($purple-color, $lightness: 25%);
-$pink-color: #f92080 !default;
+$pink-color: #d6437d !default;
 $pink-color-light: #ffdddd !default;
-$yellow-color: #efcc00 !default;
+$yellow-color: #d9a93a !default;
 
-$grey-color: #828282 !default;
-$grey-color-light: color.adjust($grey-color, $lightness: 40%);
+$grey-color: #6b7177 !default;
+$grey-color-light: #eef0f3;
+$grey-color-mid: #d8dde2;
+$grey-color-border: #e2e5ea;
 $grey-color-dark: #1c1c1d;
 $grey-900: #212529;
+$grey-page-bg: #fbfbf8;
+$panel-bg: #ffffff;
+$panel-header-bg: #f6f7f9;
 
 $white-color: #ffffff !default;
 $black-color: #000000 !default;

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -29,12 +29,12 @@ $yellow-color: #d9a93a !default;
 $grey-color: #6b7177 !default;
 $grey-color-light: #eef0f3;
 $grey-color-mid: #d8dde2;
-$grey-color-border: #e2e5ea;
+$grey-color-border: #d6d3cc;
 $grey-color-dark: #1c1c1d;
 $grey-900: #212529;
-$grey-page-bg: #faf8f4;
+$grey-page-bg: #f3efe6;
 $panel-bg: #ffffff;
-$panel-header-bg: #f4f5f7;
+$panel-header-bg: #ebe7dd;
 
 $white-color: #ffffff !default;
 $black-color: #000000 !default;

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -29,12 +29,12 @@ $yellow-color: #d9a93a !default;
 $grey-color: #6b7177 !default;
 $grey-color-light: #eef0f3;
 $grey-color-mid: #d8dde2;
-$grey-color-border: #d6d3cc;
+$grey-color-border: #b0aca0;
 $grey-color-dark: #1c1c1d;
 $grey-900: #212529;
-$grey-page-bg: #f3efe6;
+$grey-page-bg: #f7f4ec;
 $panel-bg: #ffffff;
-$panel-header-bg: #ebe7dd;
+$panel-header-bg: #f0ece1;
 
 $white-color: #ffffff !default;
 $black-color: #000000 !default;

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -32,9 +32,9 @@ $grey-color-mid: #d8dde2;
 $grey-color-border: #e2e5ea;
 $grey-color-dark: #1c1c1d;
 $grey-900: #212529;
-$grey-page-bg: #fbfbf8;
+$grey-page-bg: #faf8f4;
 $panel-bg: #ffffff;
-$panel-header-bg: #f6f7f9;
+$panel-header-bg: #f4f5f7;
 
 $white-color: #ffffff !default;
 $black-color: #000000 !default;

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -11,6 +11,7 @@ $max-content-width: {{ site.max_width }};
   "themes",
   "layout",
   "base",
+  "panels",
   "distill",
   "cv",
   "tabs",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Applies the dashboard reference's visual style (border, shape, color, font) to the existing al-folio site **without changing the page structure**, with a polished mobile layout.

### Walkthrough

[Mobile homepage at 375px — hero photo on the right, natural-ratio thumbnails](https://cursor.com/agents/bc-d7360f0f-c034-44f4-bb2e-9101693ec2a2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile3_home.png)
[Desktop homepage](https://cursor.com/agents/bc-d7360f0f-c034-44f4-bb2e-9101693ec2a2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdesktop3_home.png)
[Publications panel — borderless natural-ratio thumbnails](https://cursor.com/agents/bc-d7360f0f-c034-44f4-bb2e-9101693ec2a2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fv8_publications.png)

### Highlights

- **Panel borders**: `2px` solid warm gray (`#b0aca0`) outer outline + lighter tan (`#d6d3cc`) inner row dividers. No drop shadows anywhere.
- **Warm cream paper palette** — page `#f7f4ec`, panel header `#f0ece1`, panels white.
- **Saturated venue-badge pills** + subtle outlined link buttons.
- **Inter / JetBrains Mono** typography.
- **Publication thumbnails** are borderless and displayed at their **natural aspect ratio** — capped to `110px` wide on desktop / `80px` wide on mobile.
- **Hero panel**: photo always on the right next to the name/bio, ~`130px` desktop / `96px` mobile / `84px` <480px — no awkward stacking.
- **Mobile (`< 768px`)**:
  - Publication entries flip to vertical: thumbnail + venue pill in a horizontal mini-row, then full-width title / authors / metadata / link buttons.
  - Larger social icon hit targets (`~36px`).
  - Tighter panel padding, trimmed hero typography, smaller link buttons under `480px` so multi-button papers don't blow up the row.
- Layouts (`_layouts/about.liquid`, `page.liquid`, `post.liquid`, `_pages/blog.md`) keep the original al-folio structure.
- Dropped unused `mini_racer` from the Gemfile so a fresh `bundle install` succeeds.

### Testing

- ✅ `bundle install`
- ✅ `bundle exec jekyll serve --host 0.0.0.0 --port 4000`
- ✅ `curl -s -o /dev/null -w "%{http_code}\n" http://localhost:4000/` → `200`
- ✅ Manual visual verification in Chrome via the computer-use subagent at desktop (`1280px`) and mobile (`375px`, `414px`) — confirmed no horizontal overflow, hero photo right-positioned at all sizes, publication thumbnails render at natural aspect ratio, social icons hit-target sized, footer not overlapping content.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7360f0f-c034-44f4-bb2e-9101693ec2a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7360f0f-c034-44f4-bb2e-9101693ec2a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

